### PR TITLE
feat: error overhaul

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,15 @@
+name: "Check: Tests"
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      # check tests and doc tests separately
+      - name: check unit and integration tests
+        run: cargo test --release --all-features --no-fail-fast --workspace --lib --bins --tests
+      - name: check doctests
+        run: cargo test --doc --all-features --workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-06-11
+
+### Added
+
+- CI for running cargo (doc)tests
+
+### Changed
+
+- Overhauled error handling to a more Rust idiomatic way
+- Renamed `RsError` to `Error` (breaking!!)
+- Correct return value for `send_request_multipart`
+- Changed the way the library handles bool as u8 (now more ergonomically)
+
+### Fixed
+
+- Missing builder methods
+- Fragile URL assembly
+- Fallible `ClientBuilder.base_url()`
+- Incorrect types for `SearchGetPreviewsRequest`
+- Non-compiling doctests
+
 ## [0.1.2] - 2026-06-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "resourcespace-client"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "dotenvy",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resourcespace-client"
 edition = "2024"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Connor Kooistra"]
 description = "A Rust client for the communicating with ResourceSpace API"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@ This example initializes a simple client to search for resources and then update
 
 ```rust,no_run
 use resourcespace_client::Client;
+use resourcespace_client::api::search::DoSearchRequest;
+use resourcespace_client::api::metadata::UpdateFieldRequest;
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::builder()
-        .base_url("https://your-rs-instance.com/")?
+        .base_url("https://your-rs-instance.com/")
         .user_key("your_username", "your_api_key")
-        .build()?;
+        .build()
+        .await?;
 
     // Search for resources
     let results = client

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,7 +15,6 @@ async fn main() {
 
     let client = Client::builder()
         .base_url(&base_url)
-        .expect("Error when setting base_url")
         .user_key(&user, &key)
         // .session_key(&user, &password)
         .build()

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -14,7 +14,6 @@ async fn main() {
 
     let client = Client::builder()
         .base_url(&base_url)
-        .expect("Error when setting base_url")
         .user_key(&user, &key)
         // .session_key(&user, &password)
         .build()

--- a/justfile
+++ b/justfile
@@ -7,6 +7,9 @@ fmt:
 fmt-check:
     @cargo fmt --check
 
+test:
+    @cargo test --all-features --no-fail-fast
+
 clippy:
     @cargo clippy --all-targets --all-features -- -D warnings
 

--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -6,7 +6,7 @@ use validator::Validate;
 use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
-use super::{List, SortOrder};
+use super::{List, SortOrder, bool_as_u8, opt_bool_as_u8};
 
 /// Sub-API for collection endpoints.
 #[derive(Debug)]
@@ -328,8 +328,12 @@ impl RemoveResourceFromCollectionRequest {
 pub struct CreateCollectionRequest {
     /// The name of the new collection.
     pub name: String,
-    /// If set, marks this collection as an upload collection.
-    pub forupload: Option<u8>,
+    /// If true, marks this collection as an upload collection.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub forupload: Option<bool>,
 }
 
 impl CreateCollectionRequest {
@@ -341,7 +345,7 @@ impl CreateCollectionRequest {
     }
 
     pub fn forupload(mut self, forupload: bool) -> Self {
-        self.forupload = Some(forupload as u8);
+        self.forupload = Some(forupload);
         self
     }
 }
@@ -369,8 +373,12 @@ pub struct SearchPublicCollectionsRequest {
     pub order_by: Option<String>,
     /// Sort direction for the results.
     pub sort: Option<SortOrder>,
-    /// If set, excludes theme/featured collections from results.
-    pub exclude_themes: Option<u8>,
+    /// If true, excludes theme/featured collections from results.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub exclude_themes: Option<bool>,
 }
 
 impl SearchPublicCollectionsRequest {
@@ -394,7 +402,7 @@ impl SearchPublicCollectionsRequest {
     }
 
     pub fn exclude_themes(mut self, exclude_themes: bool) -> Self {
-        self.exclude_themes = Some(exclude_themes as u8);
+        self.exclude_themes = Some(exclude_themes);
         self
     }
 }
@@ -404,12 +412,12 @@ impl SearchPublicCollectionsRequest {
 pub struct GetCollectionRequest {
     /// The ID of the collection to retrieve.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub collection_id: u32,
 }
 
 impl GetCollectionRequest {
-    pub fn new(r#ref: u32) -> Self {
-        Self { r#ref }
+    pub fn new(collection_id: u32) -> Self {
+        Self { collection_id }
     }
 }
 
@@ -419,45 +427,113 @@ impl GetCollectionRequest {
 pub struct SaveCollectionRequest {
     /// The ID of the collection to save.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub collection_id: u32,
     /// JSON object containing the collection fields to update (e.g. name, description, public).
     #[serde_as(as = "JsonString")]
     pub coldata: SaveCollectionColdata,
 }
 
 impl SaveCollectionRequest {
-    pub fn new(r#ref: u32, coldata: SaveCollectionColdata) -> Self {
-        Self { r#ref, coldata }
+    pub fn new(collection_id: u32, coldata: SaveCollectionColdata) -> Self {
+        Self {
+            collection_id,
+            coldata,
+        }
     }
 }
 
 #[non_exhaustive]
-#[derive(Clone, Debug, PartialEq, Serialize, Validate)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Validate)]
 pub struct SaveCollectionColdata {
     /// Comma-separated value of keywords to be associated with this collection.
     pub keywords: Option<List<String>>,
-    /// To set whether other users are allowed to add/remove resources when collection is shared or is public. The allowed value is 0 or 1.
-    #[validate(range(min = 0, max = 1))]
-    pub allow_changes: Option<u8>,
+    /// If true, other users are allowed to add/remove resources when collection is shared or is public.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_changes: Option<bool>,
     /// Comma-separated value of users to attach to the collection.
     pub users: Option<List<String>>,
     /// Collection name.
     pub name: Option<String>,
-    /// 0 for private, 1 for public (legacy).
-    #[validate(range(min = 0, max = 1))]
-    pub public: Option<u8>,
+    /// If true, public. Otherwise private (legacy).
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub public: Option<bool>,
     /// 0 = standard, 3 = Featured collection, 4 = public. If 3 or 4 then public should be set to 1.
     #[serde(rename = "type")]
     pub r#type: Option<u8>,
     /// ID of parent featured collection. Set to 0 to create a new root level collection (see below). Applies to Featured collections only.
     pub parent: Option<u32>,
-    /// Required to be set to 1 if creating a root level featured collection (parent=0). Applies to Featured collections only.
-    #[validate(range(min = 0, max = 1))]
-    pub force_featured_collection_type: Option<u8>,
+    /// If true, creates a root level featured collection (parent=0). Applies to Featured collections only.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub force_featured_collection_type: Option<bool>,
     /// 0 = no image, 1 = most popular image, 10 - most popular images, 100 - manually select image. Applies to Featured collections only.
     pub thumbnail_selection_method: Option<u32>,
     /// Resource ID to use as thumbnail. Only if thumbnail_selection_method =100. Applies to Featured collections only.
     pub bg_img_resource_ref: Option<u32>,
+}
+
+impl SaveCollectionColdata {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn keywords(mut self, keywords: impl Into<List<String>>) -> Self {
+        self.keywords = Some(keywords.into());
+        self
+    }
+
+    pub fn allow_changes(mut self, allow_changes: bool) -> Self {
+        self.allow_changes = Some(allow_changes);
+        self
+    }
+
+    pub fn users(mut self, users: impl Into<List<String>>) -> Self {
+        self.users = Some(users.into());
+        self
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub fn public(mut self, public: bool) -> Self {
+        self.public = Some(public);
+        self
+    }
+
+    pub fn r#type(mut self, r#type: u8) -> Self {
+        self.r#type = Some(r#type);
+        self
+    }
+
+    pub fn parent(mut self, parent: u32) -> Self {
+        self.parent = Some(parent);
+        self
+    }
+
+    pub fn force_featured_collection_type(mut self, force: bool) -> Self {
+        self.force_featured_collection_type = Some(force);
+        self
+    }
+
+    pub fn thumbnail_selection_method(mut self, method: u32) -> Self {
+        self.thumbnail_selection_method = Some(method);
+        self
+    }
+
+    pub fn bg_img_resource_ref(mut self, resource_ref: u32) -> Self {
+        self.bg_img_resource_ref = Some(resource_ref);
+        self
+    }
 }
 
 #[non_exhaustive]
@@ -465,8 +541,9 @@ pub struct SaveCollectionColdata {
 pub struct ShowHideCollectionRequest {
     /// The ID of the collection to show or hide.
     pub collection: u32,
-    /// If set, shows the collection in the drop-down list.
-    pub show: u8,
+    /// If true, shows the collection in the drop-down list. Otherwise, hides it.
+    #[serde(serialize_with = "bool_as_u8")]
+    pub show: bool,
     /// The ID of the user whose drop-down list is being updated.
     pub user: u32,
 }
@@ -475,7 +552,7 @@ impl ShowHideCollectionRequest {
     pub fn new(collection: u32, show: bool, user: u32) -> Self {
         Self {
             collection,
-            show: show as u8,
+            show: show,
             user,
         }
     }
@@ -524,11 +601,14 @@ impl DeleteResourcesInCollectionRequest {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetCollectionsResourceCountRequest {
     /// Comma-separated list of collection IDs to retrieve resource counts for.
-    pub refs: List<u32>,
+    #[serde(rename = "refs")]
+    pub collection_ids: List<u32>,
 }
 
 impl GetCollectionsResourceCountRequest {
-    pub fn new(refs: impl Into<List<u32>>) -> Self {
-        Self { refs: refs.into() }
+    pub fn new(collection_ids: impl Into<List<u32>>) -> Self {
+        Self {
+            collection_ids: collection_ids.into(),
+        }
     }
 }

--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -3,7 +3,7 @@ use serde_with::json::JsonString;
 use serde_with::{serde_as, skip_serializing_none};
 use validator::Validate;
 
-use crate::client::Client;
+use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
 use super::{List, SortOrder};
@@ -34,7 +34,7 @@ impl<'a> CollectionApi<'a> {
     /// ```
     pub async fn get_user_collections(&self) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_user_collections", reqwest::Method::GET, ())
+            .send_request("get_user_collections", HttpMethod::Get, ())
             .await
     }
 
@@ -54,7 +54,7 @@ impl<'a> CollectionApi<'a> {
         request: AddResourceToCollectionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("add_resource_to_collection", reqwest::Method::POST, request)
+            .send_request("add_resource_to_collection", HttpMethod::Post, request)
             .await
     }
 
@@ -74,11 +74,7 @@ impl<'a> CollectionApi<'a> {
         request: RemoveResourceFromCollectionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request(
-                "remove_resource_from_collection",
-                reqwest::Method::POST,
-                request,
-            )
+            .send_request("remove_resource_from_collection", HttpMethod::Post, request)
             .await
     }
 
@@ -98,7 +94,7 @@ impl<'a> CollectionApi<'a> {
         request: CreateCollectionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("create_collection", reqwest::Method::POST, request)
+            .send_request("create_collection", HttpMethod::Post, request)
             .await
     }
 
@@ -118,7 +114,7 @@ impl<'a> CollectionApi<'a> {
         request: DeleteCollectionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("delete_collection", reqwest::Method::POST, request)
+            .send_request("delete_collection", HttpMethod::Post, request)
             .await
     }
 
@@ -138,7 +134,7 @@ impl<'a> CollectionApi<'a> {
         request: SearchPublicCollectionsRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("search_public_collections", reqwest::Method::GET, request)
+            .send_request("search_public_collections", HttpMethod::Get, request)
             .await
     }
 
@@ -160,7 +156,7 @@ impl<'a> CollectionApi<'a> {
         request: GetCollectionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_collection", reqwest::Method::GET, request)
+            .send_request("get_collection", HttpMethod::Get, request)
             .await
     }
 
@@ -180,7 +176,7 @@ impl<'a> CollectionApi<'a> {
         request: SaveCollectionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("save_collection", reqwest::Method::POST, request)
+            .send_request("save_collection", HttpMethod::Post, request)
             .await
     }
 
@@ -200,7 +196,7 @@ impl<'a> CollectionApi<'a> {
         request: ShowHideCollectionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("show_hide_collection", reqwest::Method::POST, request)
+            .send_request("show_hide_collection", HttpMethod::Post, request)
             .await
     }
 
@@ -220,7 +216,7 @@ impl<'a> CollectionApi<'a> {
         request: SendCollectionToAdminRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("send_collection_to_admin", reqwest::Method::POST, request)
+            .send_request("send_collection_to_admin", HttpMethod::Post, request)
             .await
     }
 
@@ -240,7 +236,7 @@ impl<'a> CollectionApi<'a> {
         request: GetFeaturedCollectionsRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_featured_collections", reqwest::Method::GET, request)
+            .send_request("get_featured_collections", HttpMethod::Get, request)
             .await
     }
 
@@ -262,11 +258,7 @@ impl<'a> CollectionApi<'a> {
         request: DeleteResourcesInCollectionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request(
-                "delete_resources_in_collection",
-                reqwest::Method::POST,
-                request,
-            )
+            .send_request("delete_resources_in_collection", HttpMethod::Post, request)
             .await
     }
 
@@ -289,11 +281,7 @@ impl<'a> CollectionApi<'a> {
         request: GetCollectionsResourceCountRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request(
-                "get_collections_resource_count",
-                reqwest::Method::GET,
-                request,
-            )
+            .send_request("get_collections_resource_count", HttpMethod::Get, request)
             .await
     }
 }

--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -552,7 +552,7 @@ impl ShowHideCollectionRequest {
     pub fn new(collection: u32, show: bool, user: u32) -> Self {
         Self {
             collection,
-            show: show,
+            show,
             user,
         }
     }

--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -4,7 +4,7 @@ use serde_with::{serde_as, skip_serializing_none};
 use validator::Validate;
 
 use crate::client::Client;
-use crate::error::RsError;
+use crate::error::Error;
 
 use super::{List, SortOrder};
 
@@ -32,7 +32,7 @@ impl<'a> CollectionApi<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_user_collections(&self) -> Result<serde_json::Value, RsError> {
+    pub async fn get_user_collections(&self) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_user_collections", reqwest::Method::GET, ())
             .await
@@ -52,7 +52,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn add_resource_to_collection(
         &self,
         request: AddResourceToCollectionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("add_resource_to_collection", reqwest::Method::POST, request)
             .await
@@ -72,7 +72,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn remove_resource_from_collection(
         &self,
         request: RemoveResourceFromCollectionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request(
                 "remove_resource_from_collection",
@@ -96,7 +96,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn create_collection(
         &self,
         request: CreateCollectionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("create_collection", reqwest::Method::POST, request)
             .await
@@ -116,7 +116,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn delete_collection(
         &self,
         request: DeleteCollectionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("delete_collection", reqwest::Method::POST, request)
             .await
@@ -136,7 +136,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn search_public_collections(
         &self,
         request: SearchPublicCollectionsRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("search_public_collections", reqwest::Method::GET, request)
             .await
@@ -158,7 +158,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn get_collection(
         &self,
         request: GetCollectionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_collection", reqwest::Method::GET, request)
             .await
@@ -178,7 +178,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn save_collection(
         &self,
         request: SaveCollectionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("save_collection", reqwest::Method::POST, request)
             .await
@@ -198,7 +198,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn show_hide_collection(
         &self,
         request: ShowHideCollectionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("show_hide_collection", reqwest::Method::POST, request)
             .await
@@ -218,7 +218,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn send_collection_to_admin(
         &self,
         request: SendCollectionToAdminRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("send_collection_to_admin", reqwest::Method::POST, request)
             .await
@@ -238,7 +238,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn get_featured_collections(
         &self,
         request: GetFeaturedCollectionsRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_featured_collections", reqwest::Method::GET, request)
             .await
@@ -260,7 +260,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn delete_resources_in_collection(
         &self,
         request: DeleteResourcesInCollectionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request(
                 "delete_resources_in_collection",
@@ -287,7 +287,7 @@ impl<'a> CollectionApi<'a> {
     pub async fn get_collections_resource_count(
         &self,
         request: GetCollectionsResourceCountRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request(
                 "get_collections_resource_count",

--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -286,6 +286,7 @@ impl<'a> CollectionApi<'a> {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct AddResourceToCollectionRequest {
     /// The ID of the resource to add.
@@ -303,6 +304,7 @@ impl AddResourceToCollectionRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RemoveResourceFromCollectionRequest {
     /// The ID of the resource to remove.
@@ -320,6 +322,7 @@ impl RemoveResourceFromCollectionRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CreateCollectionRequest {
@@ -343,6 +346,7 @@ impl CreateCollectionRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DeleteCollectionRequest {
     /// The ID of the collection to delete.
@@ -355,6 +359,7 @@ impl DeleteCollectionRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct SearchPublicCollectionsRequest {
@@ -394,6 +399,7 @@ impl SearchPublicCollectionsRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetCollectionRequest {
     /// The ID of the collection to retrieve.
@@ -407,6 +413,7 @@ impl GetCollectionRequest {
     }
 }
 
+#[non_exhaustive]
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SaveCollectionRequest {
@@ -424,6 +431,7 @@ impl SaveCollectionRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize, Validate)]
 pub struct SaveCollectionColdata {
     /// Comma-separated value of keywords to be associated with this collection.
@@ -452,6 +460,7 @@ pub struct SaveCollectionColdata {
     pub bg_img_resource_ref: Option<u32>,
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ShowHideCollectionRequest {
     /// The ID of the collection to show or hide.
@@ -472,6 +481,7 @@ impl ShowHideCollectionRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SendCollectionToAdminRequest {
     /// The ID of the collection to send to the administrator for review.
@@ -484,6 +494,7 @@ impl SendCollectionToAdminRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetFeaturedCollectionsRequest {
     /// The ID of the parent featured collection (category) to retrieve children for. Use 0 for top-level.
@@ -496,6 +507,7 @@ impl GetFeaturedCollectionsRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DeleteResourcesInCollectionRequest {
     /// The ID of the collection whose resources should all be deleted.
@@ -508,6 +520,7 @@ impl DeleteResourcesInCollectionRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetCollectionsResourceCountRequest {
     /// Comma-separated list of collection IDs to retrieve resource counts for.

--- a/src/api/message.rs
+++ b/src/api/message.rs
@@ -50,11 +50,11 @@ impl<'a> MessageApi<'a> {
 pub struct GetUserMessageRequest {
     /// The ID of the message to retrieve.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub message_id: u32,
 }
 
 impl GetUserMessageRequest {
-    pub fn new(r#ref: u32) -> Self {
-        Self { r#ref }
+    pub fn new(message_id: u32) -> Self {
+        Self { message_id }
     }
 }

--- a/src/api/message.rs
+++ b/src/api/message.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 use crate::client::Client;
-use crate::error::RsError;
+use crate::error::Error;
 
 /// Sub-API for message endpoints.
 #[derive(Debug)]
@@ -38,7 +38,7 @@ impl<'a> MessageApi<'a> {
     pub async fn get_user_message(
         &self,
         request: GetUserMessageRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_user_message", reqwest::Method::GET, request)
             .await

--- a/src/api/message.rs
+++ b/src/api/message.rs
@@ -45,6 +45,7 @@ impl<'a> MessageApi<'a> {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetUserMessageRequest {
     /// The ID of the message to retrieve.

--- a/src/api/message.rs
+++ b/src/api/message.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::client::Client;
+use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
 /// Sub-API for message endpoints.
@@ -40,7 +40,7 @@ impl<'a> MessageApi<'a> {
         request: GetUserMessageRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_user_message", reqwest::Method::GET, request)
+            .send_request("get_user_message", HttpMethod::Get, request)
             .await
     }
 }

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -255,15 +255,15 @@ impl Serialize for FieldIdentifier {
 pub struct GetFieldOptionsRequest {
     /// The ID or shortname of the metadata field to retrieve options for.
     #[serde(rename = "ref")]
-    pub r#ref: FieldIdentifier,
+    pub field: FieldIdentifier,
     /// If set, returns additional node information alongside each option.
     pub nodeinfo: Option<bool>,
 }
 
 impl GetFieldOptionsRequest {
-    pub fn new(r#ref: impl Into<FieldIdentifier>) -> Self {
+    pub fn new(field: impl Into<FieldIdentifier>) -> Self {
         Self {
-            r#ref: r#ref.into(),
+            field: field.into(),
             nodeinfo: None,
         }
     }
@@ -298,10 +298,10 @@ impl GetNodeIdRequest {
 pub struct GetNodesRequest {
     /// The ID of the metadata field to retrieve nodes from.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub field_id: u32,
     /// Restrict results to children of this parent node ID.
     pub parent: Option<u32>,
-    /// If set, retrieves all descendant nodes recursively.
+    /// If true, retrieves all descendant nodes recursively.
     pub recursive: Option<bool>,
     /// Number of nodes to skip, used for pagination.
     pub offset: Option<u32>,
@@ -309,16 +309,16 @@ pub struct GetNodesRequest {
     pub rows: Option<u32>,
     /// Filter nodes by name (partial match).
     pub name: Option<String>,
-    /// If set, includes the number of resources using each node.
+    /// If true, includes the number of resources using each node.
     pub use_count: Option<bool>,
-    /// If set, orders results by the translated node name.
+    /// If true, orders results by the translated node name.
     pub order_by_translated_name: Option<bool>,
 }
 
 impl GetNodesRequest {
-    pub fn new(r#ref: u32) -> Self {
+    pub fn new(field_id: u32) -> Self {
         Self {
-            r#ref,
+            field_id,
             parent: None,
             recursive: None,
             offset: None,
@@ -387,16 +387,18 @@ impl AddResourceNodesRequest {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct AddResourceNodesMultiRequest {
     /// Comma-separated list of resource IDs to add nodes to.
-    pub resourceid: List<u32>,
+    #[serde(rename = "resourceid")]
+    pub resource_id: List<u32>,
     /// Comma-separated list of node IDs to add to each resource.
-    pub nodes: List<u32>,
+    #[serde(rename = "nodes")]
+    pub node_ids: List<u32>,
 }
 
 impl AddResourceNodesMultiRequest {
-    pub fn new(resourceid: impl Into<List<u32>>, nodes: impl Into<List<u32>>) -> Self {
+    pub fn new(resource_id: impl Into<List<u32>>, node_ids: impl Into<List<u32>>) -> Self {
         Self {
-            resourceid: resourceid.into(),
-            nodes: nodes.into(),
+            resource_id: resource_id.into(),
+            node_ids: node_ids.into(),
         }
     }
 }
@@ -407,7 +409,7 @@ impl AddResourceNodesMultiRequest {
 pub struct SetNodeRequest {
     /// The ID of an existing node to update, or 0 to create a new one.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub node_id: u32,
     /// The ID of the resource type field this node belongs to.
     pub resource_type_field: u32,
     /// The name of the node.
@@ -421,9 +423,9 @@ pub struct SetNodeRequest {
 }
 
 impl SetNodeRequest {
-    pub fn new(r#ref: u32, resource_type_field: u32, name: impl Into<String>) -> Self {
+    pub fn new(node_id: u32, resource_type_field: u32, name: impl Into<String>) -> Self {
         Self {
-            r#ref,
+            node_id,
             resource_type_field,
             name: name.into(),
             parent: None,
@@ -452,11 +454,13 @@ impl SetNodeRequest {
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct GetResourceTypeFieldsRequest {
     /// Comma-separated list of resource type IDs to filter fields by.
-    pub by_resource_types: Option<List<u32>>,
+    #[serde(rename = "by_resource_types")]
+    pub resource_type_ids: Option<List<u32>>,
     /// Search string to filter fields by name.
     pub find: Option<String>,
     /// Comma-separated list of field type IDs to filter by.
-    pub by_types: Option<List<u32>>,
+    #[serde(rename = "by_types")]
+    pub field_type_ids: Option<List<u32>>,
 }
 
 impl GetResourceTypeFieldsRequest {
@@ -464,8 +468,8 @@ impl GetResourceTypeFieldsRequest {
         Self::default()
     }
 
-    pub fn by_resource_types(mut self, by_resource_types: impl Into<List<u32>>) -> Self {
-        self.by_resource_types = Some(by_resource_types.into());
+    pub fn resource_type_ids(mut self, resource_type_ids: impl Into<List<u32>>) -> Self {
+        self.resource_type_ids = Some(resource_type_ids.into());
         self
     }
 
@@ -474,8 +478,8 @@ impl GetResourceTypeFieldsRequest {
         self
     }
 
-    pub fn by_types(mut self, by_types: impl Into<List<u32>>) -> Self {
-        self.by_types = Some(by_types.into());
+    pub fn field_type_ids(mut self, field_type_ids: impl Into<List<u32>>) -> Self {
+        self.field_type_ids = Some(field_type_ids.into());
         self
     }
 }
@@ -486,7 +490,8 @@ pub struct CreateResourceTypeFieldRequest {
     /// The name of the new metadata field.
     pub name: String,
     /// Comma-separated list of resource type IDs this field should apply to.
-    pub resource_types: List<u32>,
+    #[serde(rename = "resource_types")]
+    pub resource_type_ids: List<u32>,
     /// The field type, for values see the FIELD_TYPE_* constants.
     pub r#type: String,
 }
@@ -494,12 +499,12 @@ pub struct CreateResourceTypeFieldRequest {
 impl CreateResourceTypeFieldRequest {
     pub fn new(
         name: impl Into<String>,
-        resource_types: impl Into<List<u32>>,
+        resource_type_ids: impl Into<List<u32>>,
         r#type: impl Into<String>,
     ) -> Self {
         Self {
             name: name.into(),
-            resource_types: resource_types.into(),
+            resource_type_ids: resource_type_ids.into(),
             r#type: r#type.into(),
         }
     }
@@ -511,13 +516,14 @@ impl CreateResourceTypeFieldRequest {
 pub struct ToggleActiveStatesForNodesRequest {
     /// JSON-encoded array of node IDs whose active states should be toggled.
     #[serde_as(as = "JsonString")]
-    pub refs: Vec<u32>,
+    #[serde(rename = "refs")]
+    pub node_ids: Vec<u32>,
 }
 
 impl ToggleActiveStatesForNodesRequest {
-    pub fn new(refs: impl Into<List<u32>>) -> Self {
+    pub fn new(node_ids: impl Into<List<u32>>) -> Self {
         Self {
-            refs: refs.into().0,
+            node_ids: node_ids.into().into_inner(),
         }
     }
 }

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -249,6 +249,7 @@ impl Serialize for FieldIdentifier {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetFieldOptionsRequest {
@@ -273,6 +274,7 @@ impl GetFieldOptionsRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetNodeIdRequest {
     /// The name of the node to look up.
@@ -290,6 +292,7 @@ impl GetNodeIdRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetNodesRequest {
@@ -362,6 +365,7 @@ impl GetNodesRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct AddResourceNodesRequest {
     /// The ID of the resource to add nodes to.
@@ -379,6 +383,7 @@ impl AddResourceNodesRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct AddResourceNodesMultiRequest {
     /// Comma-separated list of resource IDs to add nodes to.
@@ -396,6 +401,7 @@ impl AddResourceNodesMultiRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SetNodeRequest {
@@ -441,6 +447,7 @@ impl SetNodeRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct GetResourceTypeFieldsRequest {
@@ -473,6 +480,7 @@ impl GetResourceTypeFieldsRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CreateResourceTypeFieldRequest {
     /// The name of the new metadata field.
@@ -497,6 +505,7 @@ impl CreateResourceTypeFieldRequest {
     }
 }
 
+#[non_exhaustive]
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ToggleActiveStatesForNodesRequest {
@@ -513,6 +522,7 @@ impl ToggleActiveStatesForNodesRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UpdateFieldRequest {
     /// The ID of the resource to update.

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -3,7 +3,7 @@ use serde_with::json::JsonString;
 use serde_with::{serde_as, skip_serializing_none};
 
 use crate::client::Client;
-use crate::error::RsError;
+use crate::error::Error;
 
 use super::List;
 
@@ -31,7 +31,7 @@ impl<'a> MetadataApi<'a> {
     pub async fn get_field_options(
         &self,
         request: GetFieldOptionsRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_field_options", reqwest::Method::GET, request)
             .await
@@ -50,7 +50,7 @@ impl<'a> MetadataApi<'a> {
     pub async fn get_node_id(
         &self,
         request: GetNodeIdRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_node_id", reqwest::Method::GET, request)
             .await
@@ -66,7 +66,7 @@ impl<'a> MetadataApi<'a> {
     /// ## TODO: Errors
     ///
     /// ## TODO: Examples
-    pub async fn get_nodes(&self, request: GetNodesRequest) -> Result<serde_json::Value, RsError> {
+    pub async fn get_nodes(&self, request: GetNodesRequest) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_nodes", reqwest::Method::GET, request)
             .await
@@ -85,7 +85,7 @@ impl<'a> MetadataApi<'a> {
     pub async fn add_resource_nodes(
         &self,
         request: AddResourceNodesRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("add_resource_nodes", reqwest::Method::POST, request)
             .await
@@ -104,7 +104,7 @@ impl<'a> MetadataApi<'a> {
     pub async fn add_resource_nodes_multi(
         &self,
         request: AddResourceNodesMultiRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("add_resource_nodes_multi", reqwest::Method::POST, request)
             .await
@@ -120,7 +120,7 @@ impl<'a> MetadataApi<'a> {
     /// ## TODO: Errors
     ///
     /// ## TODO: Examples
-    pub async fn set_node(&self, request: SetNodeRequest) -> Result<serde_json::Value, RsError> {
+    pub async fn set_node(&self, request: SetNodeRequest) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("set_node", reqwest::Method::POST, request)
             .await
@@ -141,7 +141,7 @@ impl<'a> MetadataApi<'a> {
     pub async fn get_resource_type_fields(
         &self,
         request: GetResourceTypeFieldsRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_resource_type_fields", reqwest::Method::GET, request)
             .await
@@ -162,7 +162,7 @@ impl<'a> MetadataApi<'a> {
     pub async fn create_resource_type_field(
         &self,
         request: CreateResourceTypeFieldRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("create_resource_type_field", reqwest::Method::POST, request)
             .await
@@ -183,7 +183,7 @@ impl<'a> MetadataApi<'a> {
     pub async fn toggle_active_state_for_nodes(
         &self,
         request: ToggleActiveStatesForNodesRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request(
                 "toggle_active_state_for_nodes",
@@ -206,7 +206,7 @@ impl<'a> MetadataApi<'a> {
     pub async fn update_field(
         &self,
         request: UpdateFieldRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("update_field", reqwest::Method::POST, request)
             .await

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Serializer};
 use serde_with::json::JsonString;
 use serde_with::{serde_as, skip_serializing_none};
 
-use crate::client::Client;
+use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
 use super::List;
@@ -33,7 +33,7 @@ impl<'a> MetadataApi<'a> {
         request: GetFieldOptionsRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_field_options", reqwest::Method::GET, request)
+            .send_request("get_field_options", HttpMethod::Get, request)
             .await
     }
 
@@ -47,12 +47,9 @@ impl<'a> MetadataApi<'a> {
     /// ## TODO: Errors
     ///
     /// ## TODO: Examples
-    pub async fn get_node_id(
-        &self,
-        request: GetNodeIdRequest,
-    ) -> Result<serde_json::Value, Error> {
+    pub async fn get_node_id(&self, request: GetNodeIdRequest) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_node_id", reqwest::Method::GET, request)
+            .send_request("get_node_id", HttpMethod::Get, request)
             .await
     }
 
@@ -68,7 +65,7 @@ impl<'a> MetadataApi<'a> {
     /// ## TODO: Examples
     pub async fn get_nodes(&self, request: GetNodesRequest) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_nodes", reqwest::Method::GET, request)
+            .send_request("get_nodes", HttpMethod::Get, request)
             .await
     }
 
@@ -87,7 +84,7 @@ impl<'a> MetadataApi<'a> {
         request: AddResourceNodesRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("add_resource_nodes", reqwest::Method::POST, request)
+            .send_request("add_resource_nodes", HttpMethod::Post, request)
             .await
     }
 
@@ -106,7 +103,7 @@ impl<'a> MetadataApi<'a> {
         request: AddResourceNodesMultiRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("add_resource_nodes_multi", reqwest::Method::POST, request)
+            .send_request("add_resource_nodes_multi", HttpMethod::Post, request)
             .await
     }
 
@@ -122,7 +119,7 @@ impl<'a> MetadataApi<'a> {
     /// ## TODO: Examples
     pub async fn set_node(&self, request: SetNodeRequest) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("set_node", reqwest::Method::POST, request)
+            .send_request("set_node", HttpMethod::Post, request)
             .await
     }
 
@@ -143,7 +140,7 @@ impl<'a> MetadataApi<'a> {
         request: GetResourceTypeFieldsRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_resource_type_fields", reqwest::Method::GET, request)
+            .send_request("get_resource_type_fields", HttpMethod::Get, request)
             .await
     }
 
@@ -164,7 +161,7 @@ impl<'a> MetadataApi<'a> {
         request: CreateResourceTypeFieldRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("create_resource_type_field", reqwest::Method::POST, request)
+            .send_request("create_resource_type_field", HttpMethod::Post, request)
             .await
     }
 
@@ -185,11 +182,7 @@ impl<'a> MetadataApi<'a> {
         request: ToggleActiveStatesForNodesRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request(
-                "toggle_active_state_for_nodes",
-                reqwest::Method::POST,
-                request,
-            )
+            .send_request("toggle_active_state_for_nodes", HttpMethod::Post, request)
             .await
     }
 
@@ -208,7 +201,7 @@ impl<'a> MetadataApi<'a> {
         request: UpdateFieldRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("update_field", reqwest::Method::POST, request)
+            .send_request("update_field", HttpMethod::Post, request)
             .await
     }
 }

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -219,8 +219,9 @@ impl<'a> MetadataApi<'a> {
 /// making it ergonomic to reference fields at call sites:
 ///
 /// ```no_run
-/// FieldIdentifier::from(72)       // numeric ID
-/// FieldIdentifier::from("title")  // shortname
+/// # use resourcespace_client::api::metadata::FieldIdentifier;
+/// let _ = FieldIdentifier::from(72u32);       // numeric ID
+/// let _ = FieldIdentifier::from("title");     // shortname
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub enum FieldIdentifier {
@@ -550,10 +551,11 @@ impl UpdateFieldRequest {
 /// Accepts plain text or a list of node IDs via named constructors:
 ///
 /// ```no_run
-/// FieldValue::from("hello")          // plain text
-/// FieldValue::from("red")            // single option
-/// FieldValue::from(42u32)            // single node ID
-/// FieldValue::from([1u32, 2, 3])     // multiple node IDs
+/// # use resourcespace_client::api::metadata::FieldValue;
+/// let _ = FieldValue::from("hello");          // plain text
+/// let _ = FieldValue::from("red");            // single option
+/// let _ = FieldValue::from(42u32);            // single node ID
+/// let _ = FieldValue::from([1u32, 2, 3]);     // multiple node IDs
 /// ```
 ///
 /// When constructed from node IDs, the `nodevalues` parameter is

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,7 +6,7 @@ pub mod search;
 pub mod system;
 pub mod user;
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use serde_with::{StringWithSeparator, formats::CommaSeparator, serde_as};
 use std::fmt::Display;
 
@@ -35,6 +35,12 @@ pub enum SortOrder {
 #[serde_as]
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct List<T: Display>(#[serde_as(as = "StringWithSeparator::<CommaSeparator, T>")] Vec<T>);
+
+impl<T: Display> List<T> {
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+}
 
 // u32
 impl From<u32> for List<u32> {
@@ -83,4 +89,40 @@ impl<const N: usize> From<[&str; N]> for List<String> {
     fn from(arr: [&str; N]) -> Self {
         Self(arr.into_iter().map(|s| s.to_string()).collect())
     }
+}
+
+// extend From and FromIterator for List
+impl<T: Display> FromIterator<T> for List<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<T: Display + Clone> From<&[T]> for List<T> {
+    fn from(arr: &[T]) -> Self {
+        Self(arr.iter().cloned().collect())
+    }
+}
+
+/// Serializes a `bool` as an integer (`1` for `true`, `0` for `false`).
+///
+/// ResourceSpace expects boolean values to be serialized as integers.
+fn bool_as_u8<S: Serializer>(b: &bool, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u8(if *b { 1 } else { 0 })
+}
+
+/// Serializes an `Option<bool>` as an integer (`1` for `Some(true)`, `0` for `Some(false)` or `None`).
+///
+/// ResourceSpace expects boolean values to be serialized as integers.
+fn opt_bool_as_u8<S: Serializer>(b: &Option<bool>, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u8(
+        // In case a Request struct has an `Option<bool>` field that is `None`,
+        // `skip_serializing_if` will omit it from the request body.
+        // If that does not happen, we should panic to notify a bad Request struct.
+        if b.expect("opt_bool_as_u8 called on None; pair with skip_serializing_if") {
+            1
+        } else {
+            0
+        },
+    )
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,9 +23,10 @@ pub enum SortOrder {
 /// making it ergonomic to pass one or many values at call sites:
 ///
 /// ```no_run
-/// List::from(42)               // single value
-/// List::from([1, 2, 3])        // array
-/// List::from(vec![1, 2, 3])    // vec
+/// # use resourcespace_client::api::List;
+/// let _ = List::from(42);               // single value
+/// let _ = List::from([1, 2, 3]);        // array
+/// let _ = List::from(vec![1, 2, 3]);    // vec
 /// ```
 ///
 /// This type exists to satisfy ResourceSpace API parameters that expect

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -100,7 +100,7 @@ impl<T: Display> FromIterator<T> for List<T> {
 
 impl<T: Display + Clone> From<&[T]> for List<T> {
     fn from(arr: &[T]) -> Self {
-        Self(arr.iter().cloned().collect())
+        Self(arr.to_vec())
     }
 }
 

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -3,7 +3,7 @@ use serde_with::json::JsonString;
 use serde_with::{serde_as, skip_serializing_none};
 use std::collections::HashMap;
 
-use crate::client::Client;
+use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
 use super::{List, SortOrder};
@@ -36,7 +36,7 @@ impl<'a> ResourceApi<'a> {
         request: AddAlternativeFileRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("add_alternative_file", reqwest::Method::POST, request)
+            .send_request("add_alternative_file", HttpMethod::Post, request)
             .await
     }
 
@@ -58,7 +58,7 @@ impl<'a> ResourceApi<'a> {
         request: CopyResourceRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("copy_resource", reqwest::Method::POST, request)
+            .send_request("copy_resource", HttpMethod::Post, request)
             .await
     }
 
@@ -79,7 +79,7 @@ impl<'a> ResourceApi<'a> {
         request: CreateResourceRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("create_resource", reqwest::Method::POST, request)
+            .send_request("create_resource", HttpMethod::Post, request)
             .await
     }
 
@@ -100,7 +100,7 @@ impl<'a> ResourceApi<'a> {
         request: DeleteAlternativeFile,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("delete_alternative_file", reqwest::Method::POST, request)
+            .send_request("delete_alternative_file", HttpMethod::Post, request)
             .await
     }
 
@@ -125,7 +125,7 @@ impl<'a> ResourceApi<'a> {
         request: DeleteResourceRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("delete_resource", reqwest::Method::POST, request)
+            .send_request("delete_resource", HttpMethod::Post, request)
             .await
     }
 
@@ -146,7 +146,7 @@ impl<'a> ResourceApi<'a> {
         request: GetAlternativeFilesRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_alternative_files", reqwest::Method::GET, request)
+            .send_request("get_alternative_files", HttpMethod::Get, request)
             .await
     }
 
@@ -167,7 +167,7 @@ impl<'a> ResourceApi<'a> {
         request: GetEditAccessRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_edit_access", reqwest::Method::GET, request)
+            .send_request("get_edit_access", HttpMethod::Get, request)
             .await
     }
 
@@ -184,7 +184,7 @@ impl<'a> ResourceApi<'a> {
         request: GetRelatedResourcesRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_related_resources", reqwest::Method::GET, request)
+            .send_request("get_related_resources", HttpMethod::Get, request)
             .await
     }
 
@@ -203,7 +203,7 @@ impl<'a> ResourceApi<'a> {
         request: GetResourceAccessRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_resource_access", reqwest::Method::GET, request)
+            .send_request("get_resource_access", HttpMethod::Get, request)
             .await
     }
 
@@ -226,11 +226,7 @@ impl<'a> ResourceApi<'a> {
         request: GetResourceAllImageSizesRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request(
-                "get_resource_all_image_sizes",
-                reqwest::Method::GET,
-                request,
-            )
+            .send_request("get_resource_all_image_sizes", HttpMethod::Get, request)
             .await
     }
 
@@ -255,7 +251,7 @@ impl<'a> ResourceApi<'a> {
     ) -> Result<serde_json::Value, Error> {
         todo!("available from RS v11.0");
         // self.client
-        //     .send_request("get_resource_comments", reqwest::Method::GET, request)
+        //     .send_request("get_resource_comments", HttpMethod::Get, request)
         //     .await
     }
 
@@ -278,7 +274,7 @@ impl<'a> ResourceApi<'a> {
         request: GetResourceDataRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_resource_data", reqwest::Method::GET, request)
+            .send_request("get_resource_data", HttpMethod::Get, request)
             .await
     }
 
@@ -299,7 +295,7 @@ impl<'a> ResourceApi<'a> {
         request: GetResourceFieldDataRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_resource_field_data", reqwest::Method::GET, request)
+            .send_request("get_resource_field_data", HttpMethod::Get, request)
             .await
     }
 
@@ -320,7 +316,7 @@ impl<'a> ResourceApi<'a> {
         request: GetResourceLogRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_resource_log", reqwest::Method::GET, request)
+            .send_request("get_resource_log", HttpMethod::Get, request)
             .await
     }
 
@@ -343,7 +339,7 @@ impl<'a> ResourceApi<'a> {
         request: GetResourcePathRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_resource_path", reqwest::Method::GET, request)
+            .send_request("get_resource_path", HttpMethod::Get, request)
             .await
     }
 
@@ -356,7 +352,7 @@ impl<'a> ResourceApi<'a> {
     /// ## TODO: Examples
     pub async fn get_resource_types(&self) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_resource_types", reqwest::Method::GET, ())
+            .send_request("get_resource_types", HttpMethod::Get, ())
             .await
     }
 
@@ -376,7 +372,7 @@ impl<'a> ResourceApi<'a> {
         request: PutResourceDataRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("put_resource_data", reqwest::Method::POST, request)
+            .send_request("put_resource_data", HttpMethod::Post, request)
             .await
     }
 
@@ -397,7 +393,7 @@ impl<'a> ResourceApi<'a> {
         request: RelateAllResourcesRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("relate_all_resources", reqwest::Method::POST, request)
+            .send_request("relate_all_resources", HttpMethod::Post, request)
             .await
     }
 
@@ -421,7 +417,7 @@ impl<'a> ResourceApi<'a> {
         request: ReplaceResourceFileRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("replace_resource_file", reqwest::Method::POST, request)
+            .send_request("replace_resource_file", HttpMethod::Post, request)
             .await
     }
 
@@ -444,7 +440,7 @@ impl<'a> ResourceApi<'a> {
         request: ResourceFileReadonlyRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("resource_file_readonly", reqwest::Method::GET, request)
+            .send_request("resource_file_readonly", HttpMethod::Get, request)
             .await
     }
 
@@ -465,7 +461,7 @@ impl<'a> ResourceApi<'a> {
         request: ResourceLogLastRowsRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("resource_log_last_rows", reqwest::Method::GET, request)
+            .send_request("resource_log_last_rows", HttpMethod::Get, request)
             .await
     }
 
@@ -489,7 +485,7 @@ impl<'a> ResourceApi<'a> {
         request: UploadFileRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("upload_file", reqwest::Method::POST, request)
+            .send_request("upload_file", HttpMethod::Post, request)
             .await
     }
 
@@ -513,7 +509,7 @@ impl<'a> ResourceApi<'a> {
         request: UploadFileByUrlRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("upload_file_by_url", reqwest::Method::POST, request)
+            .send_request("upload_file_by_url", HttpMethod::Post, request)
             .await
     }
 
@@ -557,7 +553,7 @@ impl<'a> ResourceApi<'a> {
         request: UpdateRelatedResourceRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("update_related_resource", reqwest::Method::POST, request)
+            .send_request("update_related_resource", HttpMethod::Post, request)
             .await
     }
 
@@ -578,7 +574,7 @@ impl<'a> ResourceApi<'a> {
         request: UpdateResourceTypeRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("update_resource_type", reqwest::Method::POST, request)
+            .send_request("update_resource_type", HttpMethod::Post, request)
             .await
     }
 
@@ -599,7 +595,7 @@ impl<'a> ResourceApi<'a> {
         request: GetResourceCollectionsRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_resource_collections", reqwest::Method::GET, request)
+            .send_request("get_resource_collections", HttpMethod::Get, request)
             .await
     }
 
@@ -623,7 +619,7 @@ impl<'a> ResourceApi<'a> {
         request: ValidateUploadUrlRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("validate_upload_url", reqwest::Method::GET, request)
+            .send_request("validate_upload_url", HttpMethod::Get, request)
             .await
     }
 }

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
-use super::{List, SortOrder};
+use super::{List, SortOrder, bool_as_u8, opt_bool_as_u8};
 
 #[derive(Debug)]
 pub struct ResourceApi<'a> {
@@ -696,15 +696,16 @@ impl AddAlternativeFileRequest {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CopyResourceRequest {
     /// The ID of the resource to copy.
-    pub from: u32,
+    #[serde(rename = "from")]
+    pub resource_id: u32,
     /// Resource type ID to assign to the copy; defaults to the source resource type if omitted.
     pub resource_type: Option<u32>,
 }
 
 impl CopyResourceRequest {
-    pub fn new(from: u32) -> Self {
+    pub fn new(resource_id: u32) -> Self {
         Self {
-            from,
+            resource_id,
             resource_type: None,
         }
     }
@@ -726,10 +727,18 @@ pub struct CreateResourceRequest {
     pub archive: Option<i16>,
     /// URL of a remote file to attach to the resource at creation time.
     pub url: Option<String>,
-    /// If 1, skips reading EXIF data from the attached file.
-    pub no_exif: Option<u8>,
-    /// If 1, automatically rotates the image based on EXIF orientation.
-    pub autorotate: Option<u8>,
+    /// If true, skips reading EXIF data from the attached file.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub no_exif: Option<bool>,
+    /// If true, automatically rotates the image based on EXIF orientation.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub autorotate: Option<bool>,
     /// JSON-encoded metadata fields to set on the resource at creation time.
     #[serde_as(as = "JsonString")]
     pub metadata: Option<HashMap<u32, String>>,
@@ -758,12 +767,12 @@ impl CreateResourceRequest {
     }
 
     pub fn no_exif(mut self, no_exif: bool) -> Self {
-        self.no_exif = Some(no_exif as u8);
+        self.no_exif = Some(no_exif);
         self
     }
 
     pub fn autorotate(mut self, autorotate: bool) -> Self {
-        self.autorotate = Some(autorotate as u8);
+        self.autorotate = Some(autorotate);
         self
     }
 
@@ -780,12 +789,15 @@ pub struct DeleteAlternativeFile {
     pub resource: u32,
     /// The ID of the alternative file to delete.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub alternative_file_id: u32,
 }
 
 impl DeleteAlternativeFile {
-    pub fn new(resource: u32, r#ref: u32) -> Self {
-        Self { resource, r#ref }
+    pub fn new(resource: u32, alternative_file_id: u32) -> Self {
+        Self {
+            resource,
+            alternative_file_id,
+        }
     }
 }
 
@@ -860,12 +872,12 @@ impl GetEditAccessRequest {
 pub struct GetRelatedResourcesRequest {
     /// The ID of the resource whose related resources should be returned.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub resource_id: u32,
 }
 
 impl GetRelatedResourcesRequest {
-    pub fn new(r#ref: u32) -> Self {
-        Self { r#ref }
+    pub fn new(resource_id: u32) -> Self {
+        Self { resource_id }
     }
 }
 
@@ -900,15 +912,16 @@ impl GetResourceAllImageSizesRequest {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourceCommentsRequest {
     /// The ID of the resource to retrieve comments for.
-    pub resource_ref: u32,
-    /// If set, returns comments as a flat list rather than a threaded tree.
+    #[serde(rename = "resource_ref")]
+    pub resource_id: u32,
+    /// If true, returns comments as a flat list rather than a threaded tree.
     pub flat_view: Option<bool>,
 }
 
 impl GetResourceCommentsRequest {
-    pub fn new(resource_ref: u32) -> Self {
+    pub fn new(resource_id: u32) -> Self {
         Self {
-            resource_ref,
+            resource_id,
             flat_view: None,
         }
     }
@@ -975,17 +988,25 @@ impl GetResourceLogRequest {
 pub struct GetResourcePathRequest {
     /// The ID of the resource to generate a download URL for.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub resource_id: u32,
     /// Preview size to retrieve (e.g. `"thm"`, `"scr"`, `"pre"`). Omit for the original file.
     pub size: Option<String>,
-    /// If 1, generates the preview if it does not yet exist.
-    pub generate: Option<u8>,
+    /// If true, generates the preview if it does not yet exist.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub generate: Option<bool>,
     /// Override the file extension of the returned URL.
     pub extension: Option<String>,
     /// Page number for multi-page resources (e.g. PDF).
     pub page: Option<u32>,
-    /// If 1, returns a URL to the watermarked version of the file.
-    pub watermarked: Option<u8>,
+    /// If true, returns a URL to the watermarked version of the file.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub watermarked: Option<bool>,
     /// ID of the alternative file to return a URL for, or -1 for the original.
     pub alternative: Option<i32>,
     /// If set, writes embedded metadata into the file before returning the URL.
@@ -993,9 +1014,9 @@ pub struct GetResourcePathRequest {
 }
 
 impl GetResourcePathRequest {
-    pub fn new(r#ref: u32) -> Self {
+    pub fn new(resource_id: u32) -> Self {
         Self {
-            r#ref,
+            resource_id,
             size: None,
             generate: None,
             extension: None,
@@ -1012,7 +1033,7 @@ impl GetResourcePathRequest {
     }
 
     pub fn generate(mut self, generate: bool) -> Self {
-        self.generate = Some(generate as u8);
+        self.generate = Some(generate);
         self
     }
 
@@ -1027,7 +1048,7 @@ impl GetResourcePathRequest {
     }
 
     pub fn watermarked(mut self, watermarked: bool) -> Self {
-        self.watermarked = Some(watermarked as u8);
+        self.watermarked = Some(watermarked);
         self
     }
 
@@ -1082,12 +1103,24 @@ pub struct ReplaceResourceFileRequest {
     pub resource: u32,
     /// Local server path or publicly accessible URL of the replacement file.
     pub file_location: String,
-    /// If 1, skips reading EXIF data from the replacement file.
-    pub no_exif: Option<u8>,
-    /// If 1, automatically rotates the image based on EXIF orientation.
-    pub autorotate: Option<u8>,
-    /// If 1, retains the previous file as an alternative file rather than deleting it.
-    pub keep_original: Option<u8>,
+    /// If true, skips reading EXIF data from the replacement file.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub no_exif: Option<bool>,
+    /// If true, automatically rotates the image based on EXIF orientation.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub autorotate: Option<bool>,
+    /// If true, retains the previous file as an alternative file rather than deleting it.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub keep_original: Option<bool>,
 }
 
 impl ReplaceResourceFileRequest {
@@ -1102,17 +1135,17 @@ impl ReplaceResourceFileRequest {
     }
 
     pub fn no_exif(mut self, no_exif: bool) -> Self {
-        self.no_exif = Some(no_exif as u8);
+        self.no_exif = Some(no_exif);
         self
     }
 
     pub fn autorotate(mut self, autorotate: bool) -> Self {
-        self.autorotate = Some(autorotate as u8);
+        self.autorotate = Some(autorotate);
         self
     }
 
     pub fn keep_original(mut self, keep_original: bool) -> Self {
-        self.keep_original = Some(keep_original as u8);
+        self.keep_original = Some(keep_original);
         self
     }
 }
@@ -1122,12 +1155,12 @@ impl ReplaceResourceFileRequest {
 pub struct ResourceFileReadonlyRequest {
     /// The ID of the resource to check for read-only file status.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub resource_id: u32,
 }
 
 impl ResourceFileReadonlyRequest {
-    pub fn new(r#ref: u32) -> Self {
-        Self { r#ref }
+    pub fn new(resource_id: u32) -> Self {
+        Self { resource_id }
     }
 }
 
@@ -1142,7 +1175,8 @@ pub struct ResourceLogLastRowsRequest {
     /// Maximum number of log entries to return.
     pub maxrecords: Option<u32>,
     /// Comma-separated list of field IDs to limit results to.
-    pub field: Option<List<u32>>,
+    #[serde(rename = "field")]
+    pub field_ids: Option<List<u32>>,
     /// Comma-separated list of log codes to limit results to (e.g. `"FD"` for field data changes).
     pub log_code: Option<List<String>>,
 }
@@ -1167,8 +1201,8 @@ impl ResourceLogLastRowsRequest {
         self
     }
 
-    pub fn field(mut self, field: impl Into<List<u32>>) -> Self {
-        self.field = Some(field.into());
+    pub fn field_ids(mut self, field_ids: impl Into<List<u32>>) -> Self {
+        self.field_ids = Some(field_ids.into());
         self
     }
 
@@ -1184,21 +1218,33 @@ impl ResourceLogLastRowsRequest {
 pub struct UploadFileRequest {
     /// The ID of the resource to upload the file to.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
-    /// If 1, skips reading EXIF data from the uploaded file.
-    pub no_exif: Option<u8>,
-    /// If 1, reverts to the original file instead of uploading a new one.
-    pub revert: Option<u8>,
-    /// If 1, automatically rotates the image based on EXIF orientation.
-    pub autorotate: Option<u8>,
+    pub resource_id: u32,
+    /// If true, skips reading EXIF data from the uploaded file.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub no_exif: Option<bool>,
+    /// If true, reverts to the original file instead of uploading a new one.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub revert: Option<bool>,
+    /// If true, automatically rotates the image based on EXIF orientation.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub autorotate: Option<bool>,
     /// Local server path of the file to upload (must be within `$valid_upload_paths`).
     pub file_path: Option<String>,
 }
 
 impl UploadFileRequest {
-    pub fn new(r#ref: u32) -> Self {
+    pub fn new(resource_id: u32) -> Self {
         Self {
-            r#ref,
+            resource_id,
             no_exif: None,
             revert: None,
             autorotate: None,
@@ -1207,17 +1253,17 @@ impl UploadFileRequest {
     }
 
     pub fn no_exif(mut self, no_exif: bool) -> Self {
-        self.no_exif = Some(no_exif as u8);
+        self.no_exif = Some(no_exif);
         self
     }
 
     pub fn revert(mut self, revert: bool) -> Self {
-        self.revert = Some(revert as u8);
+        self.revert = Some(revert);
         self
     }
 
     pub fn autorotate(mut self, autorotate: bool) -> Self {
-        self.autorotate = Some(autorotate as u8);
+        self.autorotate = Some(autorotate);
         self
     }
 
@@ -1233,21 +1279,33 @@ impl UploadFileRequest {
 pub struct UploadFileByUrlRequest {
     /// The ID of the resource to upload the file to.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
-    /// If 1, skips reading EXIF data from the downloaded file.
-    pub no_exif: Option<u8>,
-    /// If 1, reverts to the original file instead of uploading a new one.
-    pub revert: Option<u8>,
-    /// If 1, automatically rotates the image based on EXIF orientation.
-    pub autorotate: Option<u8>,
+    pub resource_id: u32,
+    /// If true, skips reading EXIF data from the downloaded file.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub no_exif: Option<bool>,
+    /// If true, reverts to the original file instead of uploading a new one.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub revert: Option<bool>,
+    /// If true, automatically rotates the image based on EXIF orientation.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub autorotate: Option<bool>,
     /// Publicly accessible URL for the RS server to fetch and attach (hostname must be in `$api_upload_urls`).
     pub url: Option<String>,
 }
 
 impl UploadFileByUrlRequest {
-    pub fn new(r#ref: u32) -> Self {
+    pub fn new(resource_id: u32) -> Self {
         Self {
-            r#ref,
+            resource_id,
             no_exif: None,
             revert: None,
             autorotate: None,
@@ -1256,17 +1314,17 @@ impl UploadFileByUrlRequest {
     }
 
     pub fn no_exif(mut self, no_exif: bool) -> Self {
-        self.no_exif = Some(no_exif as u8);
+        self.no_exif = Some(no_exif);
         self
     }
 
     pub fn revert(mut self, revert: bool) -> Self {
-        self.revert = Some(revert as u8);
+        self.revert = Some(revert);
         self
     }
 
     pub fn autorotate(mut self, autorotate: bool) -> Self {
-        self.autorotate = Some(autorotate as u8);
+        self.autorotate = Some(autorotate);
         self
     }
 
@@ -1329,11 +1387,13 @@ impl From<&str> for UploadSource {
 pub struct UploadMultipartRequest {
     /// The ID of the resource to upload the file to.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
-    /// If 1, skips reading EXIF data from the uploaded file.
-    pub no_exif: u8,
-    /// If 1, reverts to the original file instead of uploading a new one.
-    pub revert: u8,
+    pub resource_id: u32,
+    /// If true, skips reading EXIF data from the uploaded file.
+    #[serde(serialize_with = "bool_as_u8")]
+    pub no_exif: bool,
+    /// If true, reverts to the original file instead of uploading a new one.
+    #[serde(serialize_with = "bool_as_u8")]
+    pub revert: bool,
     /// If set, only generates a preview without replacing the stored file.
     pub previewonly: Option<bool>,
     /// ID of an alternative file slot to upload into instead of the primary file.
@@ -1341,11 +1401,18 @@ pub struct UploadMultipartRequest {
 }
 
 impl UploadMultipartRequest {
-    pub fn new(r#ref: u32, no_exif: bool, revert: bool) -> Self {
+    /// Creates a new `UploadMultipartRequest` with the given parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `resource_id` - The ID of the resource to upload the file to.
+    /// * `no_exif` - If true, skips reading EXIF data from the uploaded file.
+    /// * `revert` - If true, reverts to the original file instead of uploading a new one.
+    pub fn new(resource_id: u32, no_exif: bool, revert: bool) -> Self {
         Self {
-            r#ref,
-            no_exif: no_exif as u8,
-            revert: revert as u8,
+            resource_id,
+            no_exif,
+            revert,
             previewonly: None,
             alternative: None,
         }
@@ -1367,17 +1434,21 @@ impl UploadMultipartRequest {
 pub struct UpdateRelatedResourceRequest {
     /// The ID of the resource to update relationships for.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub resource_id: u32,
     /// Comma-separated list of resource IDs to add or remove as related resources.
     pub related: List<u32>,
-    /// If 1, adds the related resources; if 0, removes them.
-    pub add: Option<u8>,
+    /// If true, adds the related resources; if false, removes them.
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub add: Option<bool>,
 }
 
 impl UpdateRelatedResourceRequest {
-    pub fn new(r#ref: u32, related: impl Into<List<u32>>) -> Self {
+    pub fn new(resource_id: u32, related: impl Into<List<u32>>) -> Self {
         Self {
-            r#ref,
+            resource_id,
             related: related.into(),
             add: None,
         }
@@ -1385,7 +1456,7 @@ impl UpdateRelatedResourceRequest {
 
     #[allow(clippy::should_implement_trait)]
     pub fn add(mut self, add: bool) -> Self {
-        self.add = Some(add as u8);
+        self.add = Some(add);
         self
     }
 }
@@ -1413,12 +1484,12 @@ impl UpdateResourceTypeRequest {
 pub struct GetResourceCollectionsRequest {
     /// The ID of the resource to retrieve associated collections for.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub resource_id: u32,
 }
 
 impl GetResourceCollectionsRequest {
-    pub fn new(r#ref: u32) -> Self {
-        Self { r#ref }
+    pub fn new(resource_id: u32) -> Self {
+        Self { resource_id }
     }
 }
 

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -4,7 +4,7 @@ use serde_with::{serde_as, skip_serializing_none};
 use std::collections::HashMap;
 
 use crate::client::Client;
-use crate::error::RsError;
+use crate::error::Error;
 
 use super::{List, SortOrder};
 
@@ -34,7 +34,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn add_alternative_file(
         &self,
         request: AddAlternativeFileRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("add_alternative_file", reqwest::Method::POST, request)
             .await
@@ -56,7 +56,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn copy_resource(
         &self,
         request: CopyResourceRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("copy_resource", reqwest::Method::POST, request)
             .await
@@ -77,7 +77,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn create_resource(
         &self,
         request: CreateResourceRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("create_resource", reqwest::Method::POST, request)
             .await
@@ -98,13 +98,13 @@ impl<'a> ResourceApi<'a> {
     pub async fn delete_alternative_file(
         &self,
         request: DeleteAlternativeFile,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("delete_alternative_file", reqwest::Method::POST, request)
             .await
     }
 
-    pub async fn delete_comment() -> Result<serde_json::Value, RsError> {
+    pub async fn delete_comment() -> Result<serde_json::Value, Error> {
         todo!("available from RS v11.0")
     }
 
@@ -123,7 +123,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn delete_resource(
         &self,
         request: DeleteResourceRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("delete_resource", reqwest::Method::POST, request)
             .await
@@ -144,7 +144,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_alternative_files(
         &self,
         request: GetAlternativeFilesRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_alternative_files", reqwest::Method::GET, request)
             .await
@@ -165,7 +165,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_edit_access(
         &self,
         request: GetEditAccessRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_edit_access", reqwest::Method::GET, request)
             .await
@@ -182,7 +182,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_related_resources(
         &self,
         request: GetRelatedResourcesRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_related_resources", reqwest::Method::GET, request)
             .await
@@ -201,7 +201,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_resource_access(
         &self,
         request: GetResourceAccessRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_resource_access", reqwest::Method::GET, request)
             .await
@@ -224,7 +224,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_resource_all_image_sizes(
         &self,
         request: GetResourceAllImageSizesRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request(
                 "get_resource_all_image_sizes",
@@ -252,7 +252,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_resource_comments(
         &self,
         _request: GetResourceCommentsRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         todo!("available from RS v11.0");
         // self.client
         //     .send_request("get_resource_comments", reqwest::Method::GET, request)
@@ -276,7 +276,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_resource_data(
         &self,
         request: GetResourceDataRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_resource_data", reqwest::Method::GET, request)
             .await
@@ -297,7 +297,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_resource_field_data(
         &self,
         request: GetResourceFieldDataRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_resource_field_data", reqwest::Method::GET, request)
             .await
@@ -318,7 +318,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_resource_log(
         &self,
         request: GetResourceLogRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_resource_log", reqwest::Method::GET, request)
             .await
@@ -341,7 +341,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_resource_path(
         &self,
         request: GetResourcePathRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_resource_path", reqwest::Method::GET, request)
             .await
@@ -354,7 +354,7 @@ impl<'a> ResourceApi<'a> {
     /// ## TODO: Errors
     ///
     /// ## TODO: Examples
-    pub async fn get_resource_types(&self) -> Result<serde_json::Value, RsError> {
+    pub async fn get_resource_types(&self) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_resource_types", reqwest::Method::GET, ())
             .await
@@ -374,7 +374,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn put_resource_data(
         &self,
         request: PutResourceDataRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("put_resource_data", reqwest::Method::POST, request)
             .await
@@ -395,7 +395,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn relate_all_resources(
         &self,
         request: RelateAllResourcesRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("relate_all_resources", reqwest::Method::POST, request)
             .await
@@ -419,7 +419,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn replace_resource_file(
         &self,
         request: ReplaceResourceFileRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("replace_resource_file", reqwest::Method::POST, request)
             .await
@@ -442,7 +442,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn resource_file_readonly(
         &self,
         request: ResourceFileReadonlyRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("resource_file_readonly", reqwest::Method::GET, request)
             .await
@@ -463,7 +463,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn resource_log_last_rows(
         &self,
         request: ResourceLogLastRowsRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("resource_log_last_rows", reqwest::Method::GET, request)
             .await
@@ -487,7 +487,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn upload_file(
         &self,
         request: UploadFileRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("upload_file", reqwest::Method::POST, request)
             .await
@@ -511,7 +511,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn upload_file_by_url(
         &self,
         request: UploadFileByUrlRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("upload_file_by_url", reqwest::Method::POST, request)
             .await
@@ -534,7 +534,7 @@ impl<'a> ResourceApi<'a> {
         &self,
         request: UploadMultipartRequest,
         source: impl Into<UploadSource>,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_multipart_request("upload_multipart", request, source.into())
             .await
@@ -555,7 +555,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn update_related_resource(
         &self,
         request: UpdateRelatedResourceRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("update_related_resource", reqwest::Method::POST, request)
             .await
@@ -576,7 +576,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn update_resource_type(
         &self,
         request: UpdateResourceTypeRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("update_resource_type", reqwest::Method::POST, request)
             .await
@@ -597,7 +597,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn get_resource_collections(
         &self,
         request: GetResourceCollectionsRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_resource_collections", reqwest::Method::GET, request)
             .await
@@ -621,7 +621,7 @@ impl<'a> ResourceApi<'a> {
     pub async fn validate_upload_url(
         &self,
         request: ValidateUploadUrlRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("validate_upload_url", reqwest::Method::GET, request)
             .await

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -624,6 +624,7 @@ impl<'a> ResourceApi<'a> {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct AddAlternativeFileRequest {
@@ -690,6 +691,7 @@ impl AddAlternativeFileRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CopyResourceRequest {
@@ -713,6 +715,7 @@ impl CopyResourceRequest {
     }
 }
 
+#[non_exhaustive]
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -770,6 +773,7 @@ impl CreateResourceRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DeleteAlternativeFile {
     /// The ID of the resource the alternative file belongs to.
@@ -785,6 +789,7 @@ impl DeleteAlternativeFile {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DeleteResourceRequest {
     /// The ID of the resource to delete.
@@ -797,6 +802,7 @@ impl DeleteResourceRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetAlternativeFilesRequest {
@@ -836,6 +842,7 @@ impl GetAlternativeFilesRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetEditAccessRequest {
     /// The ID of the resource to check edit access for.
@@ -848,6 +855,7 @@ impl GetEditAccessRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetRelatedResourcesRequest {
     /// The ID of the resource whose related resources should be returned.
@@ -861,6 +869,7 @@ impl GetRelatedResourcesRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourceAccessRequest {
     /// The ID of the resource to retrieve the access level for.
@@ -873,6 +882,7 @@ impl GetResourceAccessRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourceAllImageSizesRequest {
     /// The ID of the resource to retrieve available preview sizes for.
@@ -885,6 +895,7 @@ impl GetResourceAllImageSizesRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourceCommentsRequest {
@@ -908,6 +919,7 @@ impl GetResourceCommentsRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourceDataRequest {
     /// The ID of the resource to retrieve top-level property data for.
@@ -920,6 +932,7 @@ impl GetResourceDataRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourceFieldDataRequest {
     /// The ID of the resource to retrieve full metadata field data for.
@@ -932,6 +945,7 @@ impl GetResourceFieldDataRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourceLogRequest {
@@ -955,6 +969,7 @@ impl GetResourceLogRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourcePathRequest {
@@ -1027,6 +1042,7 @@ impl GetResourcePathRequest {
     }
 }
 
+#[non_exhaustive]
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct PutResourceDataRequest {
@@ -1043,6 +1059,7 @@ impl PutResourceDataRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RelateAllResourcesRequest {
     /// Comma-separated list of resource IDs to relate with each other.
@@ -1057,6 +1074,7 @@ impl RelateAllResourcesRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ReplaceResourceFileRequest {
@@ -1099,6 +1117,7 @@ impl ReplaceResourceFileRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ResourceFileReadonlyRequest {
     /// The ID of the resource to check for read-only file status.
@@ -1112,6 +1131,7 @@ impl ResourceFileReadonlyRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct ResourceLogLastRowsRequest {
@@ -1158,6 +1178,7 @@ impl ResourceLogLastRowsRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UploadFileRequest {
@@ -1206,6 +1227,7 @@ impl UploadFileRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UploadFileByUrlRequest {
@@ -1255,6 +1277,7 @@ impl UploadFileByUrlRequest {
 }
 
 /// Data source for a multipart upload
+#[non_exhaustive]
 pub enum UploadSource {
     File(std::path::PathBuf),
     Stream {
@@ -1264,6 +1287,11 @@ pub enum UploadSource {
 }
 
 impl UploadSource {
+    /// Creates a file-based upload source.
+    pub fn from_file(path: impl Into<std::path::PathBuf>) -> Self {
+        UploadSource::File(path.into())
+    }
+
     /// Creates a stream-based upload source.
     ///
     /// `body` accepts anything that converts into a [`reqwest::Body`]:
@@ -1295,6 +1323,7 @@ impl From<&str> for UploadSource {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UploadMultipartRequest {
@@ -1332,6 +1361,7 @@ impl UploadMultipartRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UpdateRelatedResourceRequest {
@@ -1360,6 +1390,7 @@ impl UpdateRelatedResourceRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct UpdateResourceTypeRequest {
     /// The ID of the resource to update.
@@ -1377,6 +1408,7 @@ impl UpdateResourceTypeRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetResourceCollectionsRequest {
     /// The ID of the resource to retrieve associated collections for.
@@ -1390,6 +1422,7 @@ impl GetResourceCollectionsRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ValidateUploadUrlRequest {
     /// The URL to validate against the server's allowed `$api_upload_urls` list.

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -212,7 +212,7 @@ pub struct SearchGetPreviewsRequest {
     /// Only return resources modified within this many days.
     pub recent_search_daylimit: Option<String>,
     /// Comma-separated list of preview sizes to include URLs for (e.g. `"thm,scr,pre"`).
-    pub getsizes: Option<List<u32>>,
+    pub getsizes: Option<List<String>>,
     /// Override the preview file extension returned (e.g. `"jpg"`).
     pub previewext: Option<String>,
 }
@@ -262,7 +262,7 @@ impl SearchGetPreviewsRequest {
         self
     }
 
-    pub fn getsizes(mut self, getsizes: impl Into<List<u32>>) -> Self {
+    pub fn getsizes(mut self, getsizes: impl Into<List<String>>) -> Self {
         self.getsizes = Some(getsizes.into());
         self
     }

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -1,7 +1,7 @@
 use serde::{Serialize, Serializer};
 use serde_with::skip_serializing_none;
 
-use crate::client::Client;
+use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
 use super::{List, SortOrder};
@@ -48,7 +48,7 @@ impl<'a> SearchApi<'a> {
     /// ```
     pub async fn do_search(&self, request: DoSearchRequest) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("do_search", reqwest::Method::GET, request)
+            .send_request("do_search", HttpMethod::Get, request)
             .await
     }
 
@@ -87,7 +87,7 @@ impl<'a> SearchApi<'a> {
         request: SearchGetPreviewsRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("search_get_previews", reqwest::Method::GET, request)
+            .send_request("search_get_previews", HttpMethod::Get, request)
             .await
     }
 }

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Serializer};
 use serde_with::skip_serializing_none;
 
 use crate::client::Client;
-use crate::error::RsError;
+use crate::error::Error;
 
 use super::{List, SortOrder};
 
@@ -46,7 +46,7 @@ impl<'a> SearchApi<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn do_search(&self, request: DoSearchRequest) -> Result<serde_json::Value, RsError> {
+    pub async fn do_search(&self, request: DoSearchRequest) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("do_search", reqwest::Method::GET, request)
             .await
@@ -85,7 +85,7 @@ impl<'a> SearchApi<'a> {
     pub async fn search_get_previews(
         &self,
         request: SearchGetPreviewsRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("search_get_previews", reqwest::Method::GET, request)
             .await

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -28,7 +28,7 @@ impl<'a> SearchApi<'a> {
     ///
     /// ## Examples
     /// ```no_run
-    /// # use resourcespace_client::{Client, api::search::{DoSearchRequest}};
+    /// # use resourcespace_client::{Client, api::search::{DoSearchRequest, FetchRows}};
     /// # use resourcespace_client::api::SortOrder;
     /// # async fn example(client: Client) -> Result<(), Box<dyn std::error::Error>> {
     /// let results = client.search()
@@ -38,7 +38,7 @@ impl<'a> SearchApi<'a> {
     /// let specific_results = client.search()
     ///     .do_search(
     ///         DoSearchRequest::new("cat")
-    ///             .fetchrows("100")
+    ///             .fetchrows(FetchRows::limit(100))
     ///             .offset(50)
     ///             .archive(0)
     ///     )
@@ -63,7 +63,7 @@ impl<'a> SearchApi<'a> {
     ///
     /// ## Examples
     /// ```no_run
-    /// # use resourcespace_client::{Client, api::search::SearchGetPreviewsRequest};
+    /// # use resourcespace_client::{Client, api::search::{SearchGetPreviewsRequest, FetchRows}};
     /// # use resourcespace_client::api::SortOrder;
     /// # async fn example(client: Client) -> Result<(), Box<dyn std::error::Error>> {
     /// let results = client.search()
@@ -76,7 +76,7 @@ impl<'a> SearchApi<'a> {
     ///             .getsizes("thm,scr,pre")
     ///             .previewext("jpg")
     ///             .sort(SortOrder::Desc)
-    ///             .fetchrows("0,50")
+    ///             .fetchrows(FetchRows::page(0, 50))
     ///     )
     ///     .await?;
     /// # Ok(())
@@ -101,8 +101,9 @@ impl<'a> SearchApi<'a> {
 /// count alongside the results.
 ///
 /// ```no_run
-/// FetchRows::limit(100)         // return up to 100 results
-/// FetchRows::page(0, 50)        // return results 0–50
+/// # use resourcespace_client::api::search::FetchRows;
+/// let _ = FetchRows::limit(100);         // return up to 100 results
+/// let _ = FetchRows::page(0, 50);        // return results 0–50
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub enum FetchRows {

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -105,19 +105,20 @@ impl<'a> SearchApi<'a> {
 /// let _ = FetchRows::limit(100);         // return up to 100 results
 /// let _ = FetchRows::page(0, 50);        // return results 0–50
 /// ```
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq)]
 pub enum FetchRows {
-    /// Return up to N rows
     Limit(u32),
-    /// Return rows with explicit offset and limit, enables paginated response
     Page { offset: u32, limit: u32 },
 }
 
 impl FetchRows {
+    /// Return up to N rows
     pub fn limit(n: u32) -> Self {
         Self::Limit(n)
     }
 
+    /// Return rows with explicit offset and limit, enables paginated response
     pub fn page(offset: u32, limit: u32) -> Self {
         Self::Page { offset, limit }
     }
@@ -132,6 +133,7 @@ impl Serialize for FetchRows {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DoSearchRequest {
@@ -195,6 +197,7 @@ impl DoSearchRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SearchGetPreviewsRequest {

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -3,7 +3,7 @@ use serde_with::skip_serializing_none;
 use validator::Validate;
 
 use crate::client::Client;
-use crate::error::RsError;
+use crate::error::Error;
 
 /// Sub-API for system endpoints.
 #[derive(Debug)]
@@ -32,7 +32,7 @@ impl<'a> SystemApi<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_system_status(&self) -> Result<serde_json::Value, RsError> {
+    pub async fn get_system_status(&self) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_system_status", reqwest::Method::GET, ())
             .await
@@ -70,20 +70,20 @@ impl<'a> SystemApi<'a> {
     pub async fn get_daily_stat_summary(
         &self,
         request: GetDailyStatSummaryRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         request
             .validate()
-            .map_err(|e| RsError::Validation(e.to_string()))?;
+            .map_err(|e| Error::Validation(e.to_string()))?;
         self.client
             .send_request("get_daily_stat_summary", reqwest::Method::GET, request)
             .await
     }
 
-    pub async fn get_reports(&self) -> Result<serde_json::Value, RsError> {
+    pub async fn get_reports(&self) -> Result<serde_json::Value, Error> {
         todo!("available from RS v11.0")
     }
 
-    pub async fn do_report(&self) -> Result<serde_json::Value, RsError> {
+    pub async fn do_report(&self) -> Result<serde_json::Value, Error> {
         todo!("available from RS v11.0")
     }
 }

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use serde_with::skip_serializing_none;
 use validator::Validate;
 
-use crate::client::Client;
+use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
 /// Sub-API for system endpoints.
@@ -34,7 +34,7 @@ impl<'a> SystemApi<'a> {
     /// ```
     pub async fn get_system_status(&self) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_system_status", reqwest::Method::GET, ())
+            .send_request("get_system_status", HttpMethod::Get, ())
             .await
     }
 
@@ -73,9 +73,9 @@ impl<'a> SystemApi<'a> {
     ) -> Result<serde_json::Value, Error> {
         request
             .validate()
-            .map_err(|e| Error::Validation(e.to_string()))?;
+            .map_err(|e| Error::Validation(e.into()))?;
         self.client
-            .send_request("get_daily_stat_summary", reqwest::Method::GET, request)
+            .send_request("get_daily_stat_summary", HttpMethod::Get, request)
             .await
     }
 

--- a/src/api/system.rs
+++ b/src/api/system.rs
@@ -88,6 +88,7 @@ impl<'a> SystemApi<'a> {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Validate)]
 pub struct GetDailyStatSummaryRequest {

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use serde_with::json::JsonString;
 use serde_with::{serde_as, skip_serializing_none};
 
-use crate::client::Client;
+use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
 use super::List;
@@ -32,7 +32,7 @@ impl<'a> UserApi<'a> {
     /// ## TODO: Examples
     pub async fn checkperm(&self, request: CheckpermRequest) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("checkperm", reqwest::Method::GET, request)
+            .send_request("checkperm", HttpMethod::Get, request)
             .await
     }
 
@@ -52,7 +52,7 @@ impl<'a> UserApi<'a> {
     /// ## TODO: Examples
     pub async fn get_users(&self, request: GetUsersRequest) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_users", reqwest::Method::GET, request)
+            .send_request("get_users", HttpMethod::Get, request)
             .await
     }
 
@@ -75,7 +75,7 @@ impl<'a> UserApi<'a> {
         request: GetUsersByPermissionRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("get_users_by_permission", reqwest::Method::GET, request)
+            .send_request("get_users_by_permission", HttpMethod::Get, request)
             .await
     }
 
@@ -98,7 +98,7 @@ impl<'a> UserApi<'a> {
         request: MarkEmailAsInvalidRequest,
     ) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("mark_email_as_invalid", reqwest::Method::POST, request)
+            .send_request("mark_email_as_invalid", HttpMethod::Post, request)
             .await
     }
 
@@ -120,7 +120,7 @@ impl<'a> UserApi<'a> {
     /// ## TODO: Examples
     pub async fn save_user(&self, request: SaveUserRequest) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("save_user", reqwest::Method::POST, request)
+            .send_request("save_user", HttpMethod::Post, request)
             .await
     }
 
@@ -142,7 +142,7 @@ impl<'a> UserApi<'a> {
     /// ## TODO: Examples
     pub async fn new_user(&self, request: NewUserRequest) -> Result<serde_json::Value, Error> {
         self.client
-            .send_request("new_user", reqwest::Method::POST, request)
+            .send_request("new_user", HttpMethod::Post, request)
             .await
     }
 }

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -5,7 +5,7 @@ use serde_with::{serde_as, skip_serializing_none};
 use crate::client::{Client, HttpMethod};
 use crate::error::Error;
 
-use super::List;
+use super::{List, opt_bool_as_u8};
 
 #[derive(Debug)]
 pub struct UserApi<'a> {
@@ -246,21 +246,21 @@ impl NewUserRequest {
 pub struct SaveUserRequest {
     /// The ID of the user to update.
     #[serde(rename = "ref")]
-    pub r#ref: u32,
+    pub user_id: u32,
     /// JSON object containing the user fields to save (e.g. fullname, email, usergroup).
     #[serde_as(as = "JsonString")]
     pub data: SaveUserData,
 }
 
 impl SaveUserRequest {
-    pub fn new(r#ref: u32, data: SaveUserData) -> Self {
-        Self { r#ref, data }
+    pub fn new(user_id: u32, data: SaveUserData) -> Self {
+        Self { user_id, data }
     }
 }
 
 #[non_exhaustive]
 #[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct SaveUserData {
     /// Username used to log into the account.
     pub username: Option<String>,
@@ -283,7 +283,72 @@ pub struct SaveUserData {
     /// Whether to send the user a password reset link by email instead of setting a password directly.
     pub emailresetlink: Option<bool>,
     /// Approval state of the account.
-    pub approved: Option<u8>,
+    #[serde(
+        serialize_with = "opt_bool_as_u8",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub approved: Option<bool>,
     /// Account expiry date in `YYYY-MM-DD` format, e.g. `"2026-12-31"`.
     pub expires: Option<String>,
+}
+
+impl SaveUserData {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn username(mut self, username: impl Into<String>) -> Self {
+        self.username = Some(username.into());
+        self
+    }
+
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+
+    pub fn fullname(mut self, fullname: impl Into<String>) -> Self {
+        self.fullname = Some(fullname.into());
+        self
+    }
+
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+
+    pub fn usergroup(mut self, usergroup: u32) -> Self {
+        self.usergroup = Some(usergroup);
+        self
+    }
+
+    pub fn ip_restrict(mut self, ip_restrict: impl Into<String>) -> Self {
+        self.ip_restrict = Some(ip_restrict.into());
+        self
+    }
+
+    pub fn comments(mut self, comments: impl Into<String>) -> Self {
+        self.comments = Some(comments.into());
+        self
+    }
+
+    pub fn suggest(mut self, suggest: bool) -> Self {
+        self.suggest = Some(suggest);
+        self
+    }
+
+    pub fn emailresetlink(mut self, emailresetlink: bool) -> Self {
+        self.emailresetlink = Some(emailresetlink);
+        self
+    }
+
+    pub fn approved(mut self, approved: bool) -> Self {
+        self.approved = Some(approved);
+        self
+    }
+
+    pub fn expires(mut self, expires: impl Into<String>) -> Self {
+        self.expires = Some(expires.into());
+        self
+    }
 }

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -3,7 +3,7 @@ use serde_with::json::JsonString;
 use serde_with::{serde_as, skip_serializing_none};
 
 use crate::client::Client;
-use crate::error::RsError;
+use crate::error::Error;
 
 use super::List;
 
@@ -30,7 +30,7 @@ impl<'a> UserApi<'a> {
     /// ## TODO: Errors
     ///
     /// ## TODO: Examples
-    pub async fn checkperm(&self, request: CheckpermRequest) -> Result<serde_json::Value, RsError> {
+    pub async fn checkperm(&self, request: CheckpermRequest) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("checkperm", reqwest::Method::GET, request)
             .await
@@ -50,7 +50,7 @@ impl<'a> UserApi<'a> {
     /// ## TODO: Errors
     ///
     /// ## TODO: Examples
-    pub async fn get_users(&self, request: GetUsersRequest) -> Result<serde_json::Value, RsError> {
+    pub async fn get_users(&self, request: GetUsersRequest) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_users", reqwest::Method::GET, request)
             .await
@@ -73,7 +73,7 @@ impl<'a> UserApi<'a> {
     pub async fn get_users_by_permission(
         &self,
         request: GetUsersByPermissionRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("get_users_by_permission", reqwest::Method::GET, request)
             .await
@@ -96,7 +96,7 @@ impl<'a> UserApi<'a> {
     pub async fn mark_email_as_invalid(
         &self,
         request: MarkEmailAsInvalidRequest,
-    ) -> Result<serde_json::Value, RsError> {
+    ) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("mark_email_as_invalid", reqwest::Method::POST, request)
             .await
@@ -118,7 +118,7 @@ impl<'a> UserApi<'a> {
     /// ## TODO: Errors
     ///
     /// ## TODO: Examples
-    pub async fn save_user(&self, request: SaveUserRequest) -> Result<serde_json::Value, RsError> {
+    pub async fn save_user(&self, request: SaveUserRequest) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("save_user", reqwest::Method::POST, request)
             .await
@@ -140,7 +140,7 @@ impl<'a> UserApi<'a> {
     /// ## TODO: Errors
     ///
     /// ## TODO: Examples
-    pub async fn new_user(&self, request: NewUserRequest) -> Result<serde_json::Value, RsError> {
+    pub async fn new_user(&self, request: NewUserRequest) -> Result<serde_json::Value, Error> {
         self.client
             .send_request("new_user", reqwest::Method::POST, request)
             .await

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -147,6 +147,7 @@ impl<'a> UserApi<'a> {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CheckpermRequest {
     /// The permission string to check (e.g. `"a"` for admin, `"e"` for edit).
@@ -159,6 +160,7 @@ impl CheckpermRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct GetUsersRequest {
@@ -184,6 +186,7 @@ impl GetUsersRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GetUsersByPermissionRequest {
     /// List of permission strings; only users holding all of these are returned.
@@ -198,6 +201,7 @@ impl GetUsersByPermissionRequest {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct MarkEmailAsInvalidRequest {
     /// The email address to mark as invalid.
@@ -212,6 +216,7 @@ impl MarkEmailAsInvalidRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct NewUserRequest {
@@ -235,6 +240,7 @@ impl NewUserRequest {
     }
 }
 
+#[non_exhaustive]
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SaveUserRequest {
@@ -252,6 +258,7 @@ impl SaveUserRequest {
     }
 }
 
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct SaveUserData {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use url::Url;
 
 use crate::client::{ApiRequest, build_query};
-use crate::error::RsError;
+use crate::error::Error;
 
 /// For a ResourceSpace external client we can only communicate with a
 /// userkey or a sessionkey. `native` authmode is only available for
@@ -27,7 +27,7 @@ pub(crate) async fn login(
     api_url: &Url,
     user: &str,
     password: &str,
-) -> Result<String, RsError> {
+) -> Result<String, Error> {
     let req = ApiRequest {
         user: &user,
         function: "login",
@@ -44,13 +44,13 @@ pub(crate) async fn login(
         .get(url.as_str())
         .send()
         .await
-        .map_err(RsError::Http)?
+        .map_err(Error::Http)?
         .text()
         .await
-        .map_err(RsError::Http)?;
+        .map_err(Error::Http)?;
 
     if response.trim().to_lowercase() == "false" {
-        return Err(RsError::Api {
+        return Err(Error::Api {
             status: 401,
             message: "Invalid credentials".into(),
         });

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -21,15 +21,13 @@ struct LoginParams<'a> {
     password: &'a str,
 }
 
-// TODO: if this is truely internal, just swap to &str
+/// Logs in a user using the ResourceSpace API and returns a session key.
 pub(crate) async fn login(
     http: &Client,
-    base_url: &Url,
-    user: impl Into<String>,
-    password: impl Into<String>,
+    api_url: &Url,
+    user: &str,
+    password: &str,
 ) -> Result<String, RsError> {
-    let user = user.into();
-    let password = password.into();
     let req = ApiRequest {
         user: &user,
         function: "login",
@@ -39,10 +37,11 @@ pub(crate) async fn login(
         },
     };
     let query = build_query(&req)?;
-    let url = format!("{}api/?{}", base_url, query);
+    let mut url = api_url.clone();
+    url.set_query(Some(&query));
 
     let response = http
-        .get(&url)
+        .get(url.as_str())
         .send()
         .await
         .map_err(RsError::Http)?

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -29,14 +29,14 @@ pub(crate) async fn login(
     password: &str,
 ) -> Result<String, Error> {
     let req = ApiRequest {
-        user: &user,
+        user,
         function: "login",
         params: LoginParams {
-            username: &user,
-            password: &password,
+            username: user,
+            password,
         },
     };
-    let query = build_query(&req)?;
+    let query = build_query(&req);
     let mut url = api_url.clone();
     url.set_query(Some(&query));
 
@@ -44,16 +44,13 @@ pub(crate) async fn login(
         .get(url.as_str())
         .send()
         .await
-        .map_err(Error::Http)?
+        .map_err(|e| Error::Transport(e.into()))? // transport/connectivity error
         .text()
         .await
-        .map_err(Error::Http)?;
+        .map_err(|e| Error::Transport(e.into()))?; // body read error
 
     if response.trim().to_lowercase() == "false" {
-        return Err(Error::Api {
-            status: 401,
-            message: "Invalid credentials".into(),
-        });
+        return Err(Error::InvalidCredentials);
     }
 
     Ok(response.trim().trim_matches('"').to_string())

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -9,7 +9,7 @@ use crate::error::Error;
 /// For a ResourceSpace external client we can only communicate with a
 /// userkey or a sessionkey. `native` authmode is only available for
 /// client side API calls -> browser initiated activity.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum Auth {
     UserKey { user: String, key: SecretString },
     SessionKey { user: String, key: SecretString },

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ mod private {
     use secrecy::SecretString;
 
     pub struct NoUrl;
-    pub struct WithUrl(pub(crate) url::Url);
+    pub struct WithUrl(pub(crate) String);
     pub struct NoAuth;
     pub struct WithUserKey {
         pub(crate) user: String,
@@ -61,7 +61,7 @@ pub(crate) fn build_query<P: Serialize>(params: &P) -> Result<String, RsError> {
 /// - "Invalid signature" strings, even with 200 status code
 #[derive(Debug)]
 pub struct Client {
-    base_url: Url,
+    api_url: Url,
     auth: Auth,
     client: reqwest::Client,
 }
@@ -115,16 +115,16 @@ impl Client {
         let request = self.prepare_request(function, params)?;
         let response = match method {
             reqwest::Method::GET => {
-                let full_url = format!(
-                    "{}api/?{}&sign={}&authmode={}",
-                    self.base_url, request.query, request.signature, request.authmode
-                );
-                self.client.get(&full_url).send().await
+                let mut url = self.api_url.clone();
+                url.set_query(Some(&format!(
+                    "{}&sign={}&authmode={}",
+                    request.query, request.signature, request.authmode
+                )));
+                self.client.get(url.as_str()).send().await
             }
             reqwest::Method::POST => {
-                let full_url = format!("{}api/", self.base_url);
                 self.client
-                    .post(&full_url)
+                    .post(self.api_url.as_str())
                     .form(&[
                         ("user", request.user.clone()),
                         ("query", request.query),
@@ -180,8 +180,6 @@ impl Client {
         P: Serialize,
     {
         let request = self.prepare_request(function, params)?;
-        let full_url = format!("{}api/", self.base_url);
-
         let file_part = match source {
             crate::api::resource::UploadSource::File(file) => reqwest::multipart::Part::file(&file)
                 .await
@@ -193,7 +191,7 @@ impl Client {
 
         let response = self
             .client
-            .post(&full_url)
+            .post(self.api_url.as_str()) // function is passed in the multipart request
             .multipart(
                 reqwest::multipart::Form::new()
                     .text("user", request.user.clone())
@@ -288,20 +286,14 @@ impl<U, A> ClientBuilder<U, A> {
 }
 
 impl<A> ClientBuilder<private::NoUrl, A> {
-    pub fn base_url(
-        self,
-        url: impl Into<String>,
-    ) -> Result<ClientBuilder<private::WithUrl, A>, RsError> {
-        let url = url.into();
-        let parsed_url = Url::parse(&url).map_err(|e| RsError::Other(e.to_string()))?;
-
-        Ok(ClientBuilder {
-            base_url: private::WithUrl(parsed_url),
+    pub fn base_url(self, url: impl Into<String>) -> ClientBuilder<private::WithUrl, A> {
+        ClientBuilder {
+            base_url: private::WithUrl(url.into()),
             auth: self.auth,
             timeout: self.timeout,
             connect_timeout: self.connect_timeout,
             user_agent: self.user_agent,
-        })
+        }
     }
 }
 
@@ -341,12 +333,24 @@ impl<U> ClientBuilder<U, private::NoAuth> {
     }
 }
 
+impl<A> ClientBuilder<private::WithUrl, A> {
+    fn parse_url(&self) -> Result<Url, RsError> {
+        let base_url = Url::parse(&self.base_url.0).map_err(|e| RsError::Other(e.to_string()))?;
+        let api_url = base_url
+            .join("api/")
+            .map_err(|e| RsError::Other(e.to_string()))?;
+
+        Ok(api_url)
+    }
+}
+
 impl ClientBuilder<private::WithUrl, private::WithSessionKey> {
     pub async fn build(self) -> Result<Client, RsError> {
+        let api_url = self.parse_url()?;
         let client = self.build_http_client()?;
         let session_key = login(
             &client,
-            &self.base_url.0,
+            &api_url,
             &self.auth.user,
             self.auth.password.expose_secret(),
         )
@@ -357,7 +361,7 @@ impl ClientBuilder<private::WithUrl, private::WithSessionKey> {
         };
 
         Ok(Client {
-            base_url: self.base_url.0,
+            api_url,
             auth,
             client,
         })
@@ -366,6 +370,7 @@ impl ClientBuilder<private::WithUrl, private::WithSessionKey> {
 
 impl ClientBuilder<private::WithUrl, private::WithUserKey> {
     pub async fn build(self) -> Result<Client, RsError> {
+        let api_url = self.parse_url()?;
         let client = self.build_http_client()?;
         let auth = Auth::UserKey {
             user: self.auth.user,
@@ -373,7 +378,7 @@ impl ClientBuilder<private::WithUrl, private::WithUserKey> {
         };
 
         Ok(Client {
-            base_url: self.base_url.0,
+            api_url,
             auth,
             client,
         })

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,5 @@
 use secrecy::{ExposeSecret, SecretString};
 use serde::Serialize;
-use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::time::Duration;
 use url::Url;
@@ -149,6 +148,11 @@ impl Client {
         let text = response.text().await.map_err(RsError::Http)?;
         let trimmed = text.trim();
 
+        // 1.5 RS returns invalid signature
+        if trimmed.eq_ignore_ascii_case("invalid_signature") {
+            return Err(RsError::Validation("invalid signature".to_string()));
+        }
+
         // 2. RS returns plain "false" for failed operations
         if trimmed.eq_ignore_ascii_case("false") {
             return Err(RsError::OperationFailed);
@@ -204,16 +208,14 @@ impl Client {
             .await
             .map_err(RsError::Http)?;
 
-        if !response.status().is_success() {
+        if response.status() != reqwest::StatusCode::NO_CONTENT {
             return Err(RsError::Api {
                 status: response.status().as_u16(),
                 message: response.text().await.unwrap_or_default(),
             });
         }
 
-        let text = response.text().await.map_err(RsError::Http)?;
-
-        Ok(json!(text))
+        Ok(serde_json::Value::String("".to_string()))
     }
 
     // Sub-APIs

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,11 +41,16 @@ struct PreparedRequest {
     authmode: String,
 }
 
-pub(crate) fn build_query<P: Serialize>(params: &P) -> Result<String, Error> {
+pub(crate) enum HttpMethod {
+    Get,
+    Post,
+}
+
+pub(crate) fn build_query<P: Serialize>(params: &P) -> String {
     serde_qs::Config::new()
         .use_form_encoding(true)
         .serialize_string(params)
-        .map_err(|e| Error::Other(format!("Failed to serialize request: {}", e)))
+        .expect("Query param serialization failed — this is a bug, please open an issue")
 }
 
 /// some endpoints return JSON with status codes, some plain text, some error with 200 status code, etc.
@@ -91,7 +96,7 @@ impl Client {
             function,
             params,
         };
-        let query = build_query(&req)?;
+        let query = build_query(&req);
         let signature = sign(key, &query);
 
         Ok(PreparedRequest {
@@ -105,7 +110,7 @@ impl Client {
     pub(crate) async fn send_request<P>(
         &self,
         function: &str,
-        method: reqwest::Method,
+        method: HttpMethod,
         params: P,
     ) -> Result<serde_json::Value, Error>
     where
@@ -113,7 +118,7 @@ impl Client {
     {
         let request = self.prepare_request(function, params)?;
         let response = match method {
-            reqwest::Method::GET => {
+            HttpMethod::Get => {
                 let mut url = self.api_url.clone();
                 url.set_query(Some(&format!(
                     "{}&sign={}&authmode={}",
@@ -121,7 +126,7 @@ impl Client {
                 )));
                 self.client.get(url.as_str()).send().await
             }
-            reqwest::Method::POST => {
+            HttpMethod::Post => {
                 self.client
                     .post(self.api_url.as_str())
                     .form(&[
@@ -133,35 +138,39 @@ impl Client {
                     .send()
                     .await
             }
-            _ => return Err(Error::Other("Unsupported HTTP method".into())),
         }
-        .map_err(Error::Http)?;
+        .map_err(|e| Error::Transport(e.into()))?;
 
         // 1. check HTTP status before touching the body
         if !response.status().is_success() {
-            return Err(Error::Api {
+            return Err(Error::Http {
                 status: response.status().as_u16(),
-                message: response.text().await.unwrap_or_default(),
+                body: response.text().await.unwrap_or_default(),
             });
         }
 
-        let text = response.text().await.map_err(Error::Http)?;
+        let text = response
+            .text()
+            .await
+            .map_err(|e| Error::Transport(e.into()))?;
         let trimmed = text.trim();
 
         // 1.5 RS returns invalid signature
         if trimmed.eq_ignore_ascii_case("invalid_signature") {
-            return Err(Error::Validation("invalid signature".to_string()));
+            return Err(Error::InvalidSignature);
         }
 
         // 2. RS returns plain "false" for failed operations
         if trimmed.eq_ignore_ascii_case("false") {
-            return Err(Error::OperationFailed);
+            return Err(Error::OperationFailed {
+                function: function.to_string(),
+            });
         }
 
         // 3. RS returns "FAILED: ..." strings from upload functions
         if let Some(msg) = trimmed.strip_prefix("FAILED:") {
             return Err(Error::Api {
-                status: 400,
+                function: function.to_string(),
                 message: msg.trim().to_string(),
             });
         }
@@ -187,7 +196,7 @@ impl Client {
         let file_part = match source {
             crate::api::resource::UploadSource::File(file) => reqwest::multipart::Part::file(&file)
                 .await
-                .map_err(|e| Error::Other(format!("Failed to read file: {}", e)))?,
+                .map_err(|e| Error::Io(e.into()))?,
             crate::api::resource::UploadSource::Stream { body, filename } => {
                 reqwest::multipart::Part::stream(body).file_name(filename)
             }
@@ -206,12 +215,12 @@ impl Client {
             )
             .send()
             .await
-            .map_err(Error::Http)?;
+            .map_err(|e| Error::Transport(e.into()))?;
 
         if response.status() != reqwest::StatusCode::NO_CONTENT {
-            return Err(Error::Api {
+            return Err(Error::Http {
                 status: response.status().as_u16(),
-                message: response.text().await.unwrap_or_default(),
+                body: response.text().await.unwrap_or_default(),
             });
         }
 
@@ -283,7 +292,7 @@ impl<U, A> ClientBuilder<U, A> {
         } else {
             builder = builder.user_agent(APP_USER_AGENT)
         }
-        Ok(builder.build()?)
+        Ok(builder.build().map_err(|e| Error::Client(e.into()))?)
     }
 }
 
@@ -337,10 +346,8 @@ impl<U> ClientBuilder<U, private::NoAuth> {
 
 impl<A> ClientBuilder<private::WithUrl, A> {
     fn parse_url(&self) -> Result<Url, Error> {
-        let base_url = Url::parse(&self.base_url.0).map_err(|e| Error::Other(e.to_string()))?;
-        let api_url = base_url
-            .join("api/")
-            .map_err(|e| Error::Other(e.to_string()))?;
+        let base_url = Url::parse(&self.base_url.0).map_err(|e| Error::Url(e.into()))?;
+        let api_url = base_url.join("api/").map_err(|e| Error::Url(e.into()))?;
 
         Ok(api_url)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use url::Url;
 
 use crate::APP_USER_AGENT;
 use crate::auth::{Auth, login};
-use crate::error::RsError;
+use crate::error::Error;
 
 // Typestates
 mod private {
@@ -41,11 +41,11 @@ struct PreparedRequest {
     authmode: String,
 }
 
-pub(crate) fn build_query<P: Serialize>(params: &P) -> Result<String, RsError> {
+pub(crate) fn build_query<P: Serialize>(params: &P) -> Result<String, Error> {
     serde_qs::Config::new()
         .use_form_encoding(true)
         .serialize_string(params)
-        .map_err(|e| RsError::Other(format!("Failed to serialize request: {}", e)))
+        .map_err(|e| Error::Other(format!("Failed to serialize request: {}", e)))
 }
 
 /// some endpoints return JSON with status codes, some plain text, some error with 200 status code, etc.
@@ -77,7 +77,7 @@ impl Client {
         }
     }
 
-    fn prepare_request<P>(&self, function: &str, params: P) -> Result<PreparedRequest, RsError>
+    fn prepare_request<P>(&self, function: &str, params: P) -> Result<PreparedRequest, Error>
     where
         P: Serialize,
     {
@@ -107,7 +107,7 @@ impl Client {
         function: &str,
         method: reqwest::Method,
         params: P,
-    ) -> Result<serde_json::Value, RsError>
+    ) -> Result<serde_json::Value, Error>
     where
         P: Serialize,
     {
@@ -133,34 +133,34 @@ impl Client {
                     .send()
                     .await
             }
-            _ => return Err(RsError::Other("Unsupported HTTP method".into())),
+            _ => return Err(Error::Other("Unsupported HTTP method".into())),
         }
-        .map_err(RsError::Http)?;
+        .map_err(Error::Http)?;
 
         // 1. check HTTP status before touching the body
         if !response.status().is_success() {
-            return Err(RsError::Api {
+            return Err(Error::Api {
                 status: response.status().as_u16(),
                 message: response.text().await.unwrap_or_default(),
             });
         }
 
-        let text = response.text().await.map_err(RsError::Http)?;
+        let text = response.text().await.map_err(Error::Http)?;
         let trimmed = text.trim();
 
         // 1.5 RS returns invalid signature
         if trimmed.eq_ignore_ascii_case("invalid_signature") {
-            return Err(RsError::Validation("invalid signature".to_string()));
+            return Err(Error::Validation("invalid signature".to_string()));
         }
 
         // 2. RS returns plain "false" for failed operations
         if trimmed.eq_ignore_ascii_case("false") {
-            return Err(RsError::OperationFailed);
+            return Err(Error::OperationFailed);
         }
 
         // 3. RS returns "FAILED: ..." strings from upload functions
         if let Some(msg) = trimmed.strip_prefix("FAILED:") {
-            return Err(RsError::Api {
+            return Err(Error::Api {
                 status: 400,
                 message: msg.trim().to_string(),
             });
@@ -179,7 +179,7 @@ impl Client {
         function: &str,
         params: P,
         source: crate::api::resource::UploadSource,
-    ) -> Result<serde_json::Value, RsError>
+    ) -> Result<serde_json::Value, Error>
     where
         P: Serialize,
     {
@@ -187,7 +187,7 @@ impl Client {
         let file_part = match source {
             crate::api::resource::UploadSource::File(file) => reqwest::multipart::Part::file(&file)
                 .await
-                .map_err(|e| RsError::Other(format!("Failed to read file: {}", e)))?,
+                .map_err(|e| Error::Other(format!("Failed to read file: {}", e)))?,
             crate::api::resource::UploadSource::Stream { body, filename } => {
                 reqwest::multipart::Part::stream(body).file_name(filename)
             }
@@ -206,10 +206,10 @@ impl Client {
             )
             .send()
             .await
-            .map_err(RsError::Http)?;
+            .map_err(Error::Http)?;
 
         if response.status() != reqwest::StatusCode::NO_CONTENT {
-            return Err(RsError::Api {
+            return Err(Error::Api {
                 status: response.status().as_u16(),
                 message: response.text().await.unwrap_or_default(),
             });
@@ -270,7 +270,7 @@ impl<U, A> ClientBuilder<U, A> {
         }
     }
 
-    fn build_http_client(&self) -> Result<reqwest::Client, RsError> {
+    fn build_http_client(&self) -> Result<reqwest::Client, Error> {
         let mut builder = reqwest::Client::builder();
         if let Some(t) = self.timeout {
             builder = builder.timeout(t);
@@ -336,18 +336,18 @@ impl<U> ClientBuilder<U, private::NoAuth> {
 }
 
 impl<A> ClientBuilder<private::WithUrl, A> {
-    fn parse_url(&self) -> Result<Url, RsError> {
-        let base_url = Url::parse(&self.base_url.0).map_err(|e| RsError::Other(e.to_string()))?;
+    fn parse_url(&self) -> Result<Url, Error> {
+        let base_url = Url::parse(&self.base_url.0).map_err(|e| Error::Other(e.to_string()))?;
         let api_url = base_url
             .join("api/")
-            .map_err(|e| RsError::Other(e.to_string()))?;
+            .map_err(|e| Error::Other(e.to_string()))?;
 
         Ok(api_url)
     }
 }
 
 impl ClientBuilder<private::WithUrl, private::WithSessionKey> {
-    pub async fn build(self) -> Result<Client, RsError> {
+    pub async fn build(self) -> Result<Client, Error> {
         let api_url = self.parse_url()?;
         let client = self.build_http_client()?;
         let session_key = login(
@@ -371,7 +371,7 @@ impl ClientBuilder<private::WithUrl, private::WithSessionKey> {
 }
 
 impl ClientBuilder<private::WithUrl, private::WithUserKey> {
-    pub async fn build(self) -> Result<Client, RsError> {
+    pub async fn build(self) -> Result<Client, Error> {
         let api_url = self.parse_url()?;
         let client = self.build_http_client()?;
         let auth = Auth::UserKey {

--- a/src/client.rs
+++ b/src/client.rs
@@ -292,7 +292,7 @@ impl<U, A> ClientBuilder<U, A> {
         } else {
             builder = builder.user_agent(APP_USER_AGENT)
         }
-        Ok(builder.build().map_err(|e| Error::Client(e.into()))?)
+        builder.build().map_err(|e| Error::Client(e.into()))
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -63,7 +63,7 @@ pub(crate) fn build_query<P: Serialize>(params: &P) -> String {
 /// - Raw integers (resource IDs)
 /// - "FAILED: ..." strings for certain errors, even with 200 status code
 /// - "Invalid signature" strings, even with 200 status code
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Client {
     api_url: Url,
     auth: Auth,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,39 @@
 use thiserror::Error;
 
-// TODO: what errors can RS return?
+// To avoid having to make certain dependencies a public dependency,
+// we use a boxed error type that can be converted from any error type.
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("API error {status}: {message}")]
-    Api { status: u16, message: String },
+    #[error("HTTP error: {status}: {body}")]
+    Http { status: u16, body: String },
 
-    #[error("Operation returned false")]
-    OperationFailed,
+    #[error("API error {function}: {message}")]
+    Api { function: String, message: String },
 
-    #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    #[error("ResourceSpace returned false during login: invalid credentials")]
+    InvalidCredentials,
 
-    #[error("Other error: {0}")]
-    Other(String),
+    #[error("ResourceSpace returned: invalid signature")]
+    InvalidSignature,
+
+    #[error("ResourceSpace returned false for `{function}`")]
+    OperationFailed { function: String },
+
+    #[error("Transport error: {0}")]
+    Transport(BoxError),
+
+    #[error("IO error: {0}")]
+    Io(#[source] BoxError),
+
+    #[error("Client error: {0}")]
+    Client(#[source] BoxError),
+
+    #[error("URL error: {0}")]
+    Url(#[source] BoxError),
 
     #[error("Validation error: {0}")]
-    Validation(String),
+    Validation(#[source] BoxError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 #[non_exhaustive]
 #[derive(Debug, Error)]
-pub enum RsError {
+pub enum Error {
     #[error("API error {status}: {message}")]
     Api { status: u16, message: String },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod auth;
 pub mod client;
 pub use client::{Client, ClientBuilder};
 pub mod error;
-pub use error::RsError;
+pub use error::Error;
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 


### PR DESCRIPTION
## [0.2.0] - 2026-06-11

Error overhaul update, solves #3 

### Added

- CI for running cargo (doc)tests

### Changed

- Overhauled error handling to a more Rust idiomatic way
- Renamed `RsError` to `Error` (breaking!!)
- Correct return value for `send_request_multipart`
- Changed the way the library handles bool as u8 (now more ergonomically)

### Fixed

- Missing builder methods
- Fragile URL assembly
- Fallible `ClientBuilder.base_url()`
- Incorrect types for `SearchGetPreviewsRequest`
- Non-compiling doctests